### PR TITLE
feat: site-health monitoring with maintainer regex-failure alerts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ venv
 __pycache__/
 *.egg-info/
 error.log
+recipe_emailer.log
 #unused_mains_recipes.json
 #unused_sides_recipes.json
 #used_recipes.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,80 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Run (sends to BCC recipients, scrapes ~18 sites, ~150s)
+python main.py
+
+# Debug mode: prompts for a single site, sends only to SENDER,
+# skips all persistence + website publish
+python main.py -d
+
+# Tests
+pytest                              # all tests
+pytest tests/test_file_utils.py -v  # single file
+pytest --cov --cov-report=term-missing
+
+# Quality gate (mirrors CI)
+mypy . --strict && ruff check . && black --check .
+
+# Production entry point (used by cron)
+./cook.sh   # cd, activate .venv, python3 main.py >> cronjob.log
+```
+
+Python ≥3.11. Dev tooling installed via `pip install -e ".[dev]"`.
+
+## Architecture
+
+Flat module layout (no package) — every module is a top-level file importing siblings directly. `main.py` orchestrates a linear pipeline; each stage lives in its own module:
+
+```
+scrape (recipe_processor → web_scraper)
+  → select proteins (recipe_selector.select_random_proteins)
+  → ensure veggies / add sides (recipe_selector.ensure_veggies)
+  → render (html_generator.generate_html_email)
+  → send (email_sender.send_email)
+  → publish to website (website_publisher.publish_meals_page)
+  → update tracking JSON (file_utils.save_json)
+```
+
+`config.py` centralizes all constants + env vars; nearly every module imports from it. `main.py` passes a single `context` dict between its private `_*` helpers.
+
+### State lives in committed JSON files
+
+The four `*_recipes.json` files in the repo root **are the database** and are tracked in git (see commits like "update DBs"). They are keyed by recipe URL:
+
+- `unused_mains_recipes.json` / `unused_sides_recipes.json` — scraped-but-not-yet-sent recipes
+- `used_recipes.json` — `{url: date_sent}`, prevents repeats
+- `failed_recipes.json` — `{url: failure_reason}`, URLs to skip
+
+On each run, `unused_mains` is re-scraped only if it's newly created or older than `FILE_AGE_THRESHOLD` (12h). When a recipe is emailed it moves from an `unused_*` file into `used_recipes`. Debug mode never writes these files.
+
+### Two recipe data shapes (easy to confuse)
+
+1. **Raw recipe** — the value stored in the JSON files: a dict from `recipe_scrapers.scrape_html(...).to_json()` with keys `title`, `ingredients`, `instructions`, `image`, `site_name`, `host`, etc. (`REQUIRED_RECIPE_KEYS` in config). A "recipe item" wraps one as `{url: recipe_dict}`.
+2. **Meal item** — what `ensure_veggies` produces and what `html_generator`/tracking consume: `{"type": ..., "obj": {url: recipe_dict}}` where `type` is `single_main`, `combo_main`, or `combo_side`. Unwrap the recipe with `info["obj"][next(iter(info["obj"]))]`.
+
+### Selection logic (recipe_selector.py)
+
+Recipes are categorized seafood vs. landfood by substring-matching `SEAFOOD_PROTEINS`/`LANDFOOD_PROTEINS` against ingredient strings. `_select_meal_mix` sends 2 land + 1 seafood when seafood exists, else 3 land, else raises `InsufficientRecipesError`. A main lacking any `VEGGIES` ingredient gets a random side dish appended (producing the `combo_*` pair).
+
+### Scraping (websites.py + web_scraper.py)
+
+`WEBSITES` maps a site name → `{regex, "main course" url, "side dish" url}`. Each site's index pages are fetched and `regex` extracts individual recipe URLs. URLs are filtered through `URL_EXCLUSION_PATTERNS` (tuple of keyword-AND groups) and individual recipe pages are parsed by the `hhursev` `recipe_scrapers` lib. Site HTML structures drift — a failing site usually means its `regex` needs updating. Failures are caught and recorded in `failed_recipes`, never fatal (this runs unattended).
+
+### Email + website publish
+
+`head.html` (repo root) supplies the email's `<head>`/CSS; `html_generator` appends `<body>` cards. `website_publisher` extracts that `<body>`, re-wraps it in the external website's template (`WEBSITE_REPO_PATH` env, with `templates/navbar.html`), writes `meals.html`, and git commit/pushes to that separate repo. Skipped if `WEBSITE_REPO_PATH` is unset or in debug mode.
+
+## Configuration
+
+`.env` (required): `SENDER`, `PASSWD` (Gmail app password), `BCC` (comma-separated recipients). Optional: `WEBSITE_REPO_PATH`.
+
+## Conventions
+
+- mypy strict + ruff + black (line length 88) are enforced in CI. Newer modules (`config`, `file_utils`, `recipe_selector`, `main`, `website_publisher`) are fully typed with docstrings; older ones (`web_scraper`, `html_generator`, `email_sender`, `recipe_processor`) are looser — match the style of the file you're editing.
+- Errors in the pipeline are logged and routed to `_send_error_notification` (emails the traceback to SENDER) rather than crashing silently; business logic avoids `sys.exit`.
+- Tests are characterization/baseline tests (`*_baseline.py`) capturing current behavior — run them before and after refactors.

--- a/config.py
+++ b/config.py
@@ -42,6 +42,8 @@ __all__ = [
     "LANDFOOD_COUNT_NO_SEAFOOD",
     "VEGGIES",
     "WEBSITE_REPO_PATH",
+    "SITE_HEALTH_FILENAME",
+    "HEALTH_SUBJECT",
 ]
 
 # VERSION TAG
@@ -55,6 +57,8 @@ UNUSED_MAINS_FILENAME: Final[str] = "unused_mains_recipes.json"
 UNUSED_SIDES_FILENAME: Final[str] = "unused_sides_recipes.json"
 FAILED_FILENAME: Final[str] = "failed_recipes.json"
 USED_FILENAME: Final[str] = "used_recipes.json"
+SITE_HEALTH_FILENAME: Final[str] = "site_health.json"
+HEALTH_SUBJECT: Final[str] = "Recipe Emailer — Site Health"
 
 # FILE AGE THRESHOLD (in hours)
 FILE_AGE_THRESHOLD: Final[int] = 12

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from typing import Any
 from config import (
     FAILED_FILENAME,
     FILE_AGE_THRESHOLD,
+    HEALTH_SUBJECT,
+    SITE_HEALTH_FILENAME,
     SUBJECT,
     UNUSED_MAINS_FILENAME,
     UNUSED_SIDES_FILENAME,
@@ -31,6 +33,12 @@ from file_utils import is_file_old, load_json, save_json
 from html_generator import generate_html_email
 from recipe_processor import fetch_fresh_recipes
 from recipe_selector import ensure_veggies, select_random_proteins
+from site_health import (
+    build_report,
+    has_something_to_report,
+    record_run,
+    render_health_email,
+)
 from website_publisher import publish_meals_page
 from websites import WEBSITES
 
@@ -67,6 +75,8 @@ def main() -> None:
         # Fetch fresh recipes if needed
         if context["needs_fresh_data"]:
             _fetch_and_update_recipes(context, debug_mode)
+            if not debug_mode:
+                _monitor_site_health(context)
 
         # Select and prepare meals
         meals = _select_and_prepare_meals(context)
@@ -146,7 +156,7 @@ def _fetch_and_update_recipes(context: dict[str, Any], debug_mode: bool) -> None
     """Fetch fresh recipes and update context."""
     logger.info("Fetching fresh recipe data...")
 
-    updated_mains, updated_sides = fetch_fresh_recipes(
+    updated_mains, updated_sides, run_outcomes = fetch_fresh_recipes(
         context["websites"],
         context["unused_mains"],
         context["unused_sides"],
@@ -157,12 +167,45 @@ def _fetch_and_update_recipes(context: dict[str, Any], debug_mode: bool) -> None
 
     context["unused_mains"] = updated_mains
     context["unused_sides"] = updated_sides
+    context["run_outcomes"] = run_outcomes
 
     # Save updated data (skip in debug mode)
     if not debug_mode:
         save_json(UNUSED_MAINS_FILENAME, updated_mains)
         save_json(UNUSED_SIDES_FILENAME, updated_sides)
         logger.info("Saved updated recipe data")
+
+
+def _monitor_site_health(context: dict[str, Any]) -> None:
+    """Record per-site scrape outcomes and email the maintainer on problems.
+
+    Records this run's outcomes to SITE_HEALTH_FILENAME and, if any site's
+    regex looks broken / a site is unreachable / a site is flaky, emails a
+    summary to SENDER. Never raises — a monitoring failure must not break the
+    recipe run.
+    """
+    try:
+        outcomes = context.get("run_outcomes", [])
+        if not outcomes:
+            return
+
+        health_data, _ = load_json(SITE_HEALTH_FILENAME)
+        run_date = datetime.now().strftime("%Y-%m-%d")
+        record_run(health_data, outcomes, run_date)
+        save_json(SITE_HEALTH_FILENAME, health_data)
+
+        report = build_report(health_data)
+        if has_something_to_report(report):
+            logger.info("Site-health issues found; emailing maintainer")
+            send_email(
+                render_health_email(report),
+                debug_mode=True,  # routes Bcc to SENDER only
+                subject=HEALTH_SUBJECT,
+            )
+        else:
+            logger.info("Site health all clear; no maintainer email")
+    except Exception as e:
+        logger.exception(f"Site-health monitoring failed: {e}")
 
 
 def _select_and_prepare_meals(context: dict[str, Any]) -> list[dict[str, Any]]:

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -9,6 +9,7 @@ from config import (
     UNUSED_SIDES_FILENAME,
 )
 from file_utils import save_json
+from site_health import RunOutcome
 from web_scraper import get_html, get_recipe_urls, scraper
 
 
@@ -68,14 +69,28 @@ def fetch_fresh_recipes(
     used_recipes: dict,
     failed_recipes: dict,
     debug_mode: bool = False,
-) -> tuple[dict[str, dict], dict[str, dict]]:
-    """GET LATEST URLS FROM HTML, separating entrées and sides."""
+) -> tuple[dict[str, dict], dict[str, dict], list[RunOutcome]]:
+    """GET LATEST URLS FROM HTML, separating entrées and sides.
+
+    Also returns a list of per-(site, course) RunOutcome health records.
+    """
     main_urls, side_urls = [], []
+    run_outcomes: list[RunOutcome] = []
     print("Getting website HTML")
-    for site_info in tqdm(websites.values()):
-        fresh_main_urls, fresh_side_urls = get_recipe_urls(site_info, debug_mode)
+    for site_name, site_info in tqdm(websites.items()):
+        fresh_main_urls, fresh_side_urls, statuses = get_recipe_urls(
+            site_info, debug_mode
+        )
         main_urls.extend(fresh_main_urls)
         side_urls.extend(fresh_side_urls)
+        for course, (status, url_count) in statuses.items():
+            run_outcomes.append(
+                RunOutcome(
+                    key=f"{site_name} — {course}",
+                    status=status,
+                    url_count=url_count,
+                )
+            )
 
     # REMOVE DUPLICATES
     print("Removing duplicate URLs")
@@ -120,4 +135,4 @@ def fetch_fresh_recipes(
         f"side {len(unused_side_recipes)} new total"
     )
 
-    return unused_main_recipes, unused_side_recipes
+    return unused_main_recipes, unused_side_recipes, run_outcomes

--- a/site_health.py
+++ b/site_health.py
@@ -26,7 +26,7 @@ __all__ = [
     "record_run",
     "build_report",
     "has_something_to_report",
-    "render_health_email",  # noqa: F822 – added in a later task
+    "render_health_email",
 ]
 
 # Status constants
@@ -151,3 +151,30 @@ def build_report(health_data: dict[str, list[dict[str, Any]]]) -> HealthReport:
 def has_something_to_report(report: HealthReport) -> bool:
     """True iff any of the three report sections is populated."""
     return bool(report.broken or report.unreachable or report.flaky)
+
+
+def _render_section(title: str, entries: list[ReportEntry]) -> str:
+    """Render one report section, or '' if it has no entries."""
+    if not entries:
+        return ""
+    rows = "\n".join(
+        f"  <li><strong>{e.key}</strong> — current: {e.status}, "
+        f"last good: {e.last_good}, failed {e.failures} of last {e.window} runs</li>"
+        for e in entries
+    )
+    return f"<h2>{title}</h2>\n<ul>\n{rows}\n</ul>\n"
+
+
+def render_health_email(report: HealthReport) -> str:
+    """Render the HTML email body for a health report, omitting empty sections."""
+    sections = (
+        _render_section("🔴 Likely broken regex", report.broken)
+        + _render_section("🟡 Unreachable", report.unreachable)
+        + _render_section("📉 Flaky watch", report.flaky)
+    )
+    return (
+        "<html>\n<body>\n"
+        "<h1>Recipe Emailer — Site Health</h1>\n"
+        f"{sections}"
+        "</body>\n</html>\n"
+    )

--- a/site_health.py
+++ b/site_health.py
@@ -24,8 +24,8 @@ __all__ = [
     "HealthReport",
     "classify_outcome",
     "record_run",
-    "build_report",  # noqa: F822 – added in a later task
-    "has_something_to_report",  # noqa: F822 – added in a later task
+    "build_report",
+    "has_something_to_report",
     "render_health_email",  # noqa: F822 – added in a later task
 ]
 
@@ -100,3 +100,54 @@ def record_run(
         if len(window) > WINDOW_SIZE:
             del window[: len(window) - WINDOW_SIZE]
     return health_data
+
+
+def _last_good(window: list[dict[str, Any]]) -> str:
+    """Return the date of the most recent OK entry, or a 'never' sentinel."""
+    for entry in reversed(window):
+        if entry["status"] == STATUS_OK:
+            return str(entry["date"])
+    return f"never (in last {WINDOW_SIZE})"
+
+
+def _count_failures(window: list[dict[str, Any]]) -> int:
+    """Count non-OK entries within the window."""
+    return sum(1 for e in window if e["status"] in _FAILURE_STATUSES)
+
+
+def build_report(health_data: dict[str, list[dict[str, Any]]]) -> HealthReport:
+    """Compute broken / unreachable / flaky sections from the windows.
+
+    'Current' status is the most recent entry in each key's window. A key whose
+    current status is OK still lands on the flaky watch if it failed at least
+    FLAKY_THRESHOLD times within the window. A current REGEX_BROKEN/UNREACHABLE
+    status takes precedence over the flaky watch, so the flaky branch only
+    applies when the current status is OK.
+    """
+    report = HealthReport()
+
+    for key, window in health_data.items():
+        if not window:
+            continue
+        current = window[-1]["status"]
+        entry = ReportEntry(
+            key=key,
+            status=current,
+            last_good=_last_good(window),
+            failures=_count_failures(window),
+            window=len(window),
+        )
+
+        if current == STATUS_REGEX_BROKEN:
+            report.broken.append(entry)
+        elif current == STATUS_UNREACHABLE:
+            report.unreachable.append(entry)
+        elif entry.failures >= FLAKY_THRESHOLD:
+            report.flaky.append(entry)
+
+    return report
+
+
+def has_something_to_report(report: HealthReport) -> bool:
+    """True iff any of the three report sections is populated."""
+    return bool(report.broken or report.unreachable or report.flaky)

--- a/site_health.py
+++ b/site_health.py
@@ -1,0 +1,102 @@
+"""Site-health monitoring: track per-site URL-extraction outcomes over time.
+
+Records, for each (website, course) listing page, whether the scrape regex
+matched URLs, the page was unreachable, or all is well — and surfaces trends
+so the maintainer learns when a site's regex needs fixing.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "STATUS_OK",
+    "STATUS_REGEX_BROKEN",
+    "STATUS_UNREACHABLE",
+    "WINDOW_SIZE",
+    "FLAKY_THRESHOLD",
+    "RunOutcome",
+    "ReportEntry",
+    "HealthReport",
+    "classify_outcome",
+    "record_run",
+    "build_report",  # noqa: F822 – added in a later task
+    "has_something_to_report",  # noqa: F822 – added in a later task
+    "render_health_email",  # noqa: F822 – added in a later task
+]
+
+# Status constants
+STATUS_OK = "OK"
+STATUS_REGEX_BROKEN = "REGEX_BROKEN"
+STATUS_UNREACHABLE = "UNREACHABLE"
+
+# Rolling-window + flakiness tuning
+WINDOW_SIZE = 8
+FLAKY_THRESHOLD = 3
+
+_FAILURE_STATUSES = (STATUS_REGEX_BROKEN, STATUS_UNREACHABLE)
+
+
+@dataclass(frozen=True)
+class RunOutcome:
+    """One (site, course) outcome for the current run."""
+
+    key: str  # "<Site Name> — <course>"
+    status: str  # one of the STATUS_* constants
+    url_count: int
+
+
+@dataclass(frozen=True)
+class ReportEntry:
+    """A single line in the health report."""
+
+    key: str
+    status: str
+    last_good: str  # YYYY-MM-DD or "never (in last N)"
+    failures: int  # failures within the window
+    window: int  # number of runs the window currently holds
+
+
+@dataclass
+class HealthReport:
+    """Computed health report split into three sections."""
+
+    broken: list[ReportEntry] = field(default_factory=list)
+    unreachable: list[ReportEntry] = field(default_factory=list)
+    flaky: list[ReportEntry] = field(default_factory=list)
+
+
+def classify_outcome(reachable: bool, url_count: int) -> str:
+    """Classify a single index-page fetch into a status constant."""
+    if not reachable:
+        return STATUS_UNREACHABLE
+    if url_count == 0:
+        return STATUS_REGEX_BROKEN
+    return STATUS_OK
+
+
+def record_run(
+    health_data: dict[str, list[dict[str, Any]]],
+    outcomes: list[RunOutcome],
+    run_date: str,
+) -> dict[str, list[dict[str, Any]]]:
+    """Append each outcome to its key's window and prune to WINDOW_SIZE.
+
+    Mutates and returns health_data.
+    """
+    for outcome in outcomes:
+        window = health_data.setdefault(outcome.key, [])
+        window.append(
+            {
+                "date": run_date,
+                "status": outcome.status,
+                "url_count": outcome.url_count,
+            }
+        )
+        if len(window) > WINDOW_SIZE:
+            del window[: len(window) - WINDOW_SIZE]
+    return health_data

--- a/tests/test_main_health_baseline.py
+++ b/tests/test_main_health_baseline.py
@@ -1,0 +1,76 @@
+"""Tests for main._monitor_site_health wiring."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import main
+from config import HEALTH_SUBJECT
+from site_health import STATUS_OK, STATUS_REGEX_BROKEN, RunOutcome
+
+
+class TestMonitorSiteHealth:
+    @patch("main.send_email")
+    @patch("main.save_json")
+    @patch("main.load_json")
+    def test_emails_maintainer_when_regex_broken(self, mock_load, mock_save, mock_send):
+        mock_load.return_value = ({}, True)
+        context = {
+            "run_outcomes": [
+                RunOutcome(
+                    key="Site A — main course", status=STATUS_REGEX_BROKEN, url_count=0
+                )
+            ]
+        }
+
+        main._monitor_site_health(context)
+
+        mock_save.assert_called_once()
+        assert mock_send.call_count == 1
+        _, kwargs = mock_send.call_args
+        assert kwargs["debug_mode"] is True
+        assert kwargs["subject"] == HEALTH_SUBJECT
+
+    @patch("main.send_email")
+    @patch("main.save_json")
+    @patch("main.load_json")
+    def test_no_email_when_all_ok(self, mock_load, mock_save, mock_send):
+        mock_load.return_value = ({}, True)
+        context = {
+            "run_outcomes": [
+                RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=5)
+            ]
+        }
+
+        main._monitor_site_health(context)
+
+        mock_save.assert_called_once()
+        mock_send.assert_not_called()
+
+    @patch("main.send_email")
+    @patch("main.save_json")
+    @patch("main.load_json")
+    def test_no_outcomes_does_nothing(self, mock_load, mock_save, mock_send):
+        context: dict = {"run_outcomes": []}
+
+        main._monitor_site_health(context)
+
+        mock_load.assert_not_called()
+        mock_save.assert_not_called()
+        mock_send.assert_not_called()
+
+    @patch("main.send_email")
+    @patch("main.save_json")
+    @patch("main.load_json")
+    def test_never_raises_on_failure(self, mock_load, mock_save, mock_send):
+        mock_load.side_effect = OSError("disk gone")
+        context = {
+            "run_outcomes": [
+                RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=5)
+            ]
+        }
+
+        main._monitor_site_health(context)
+
+        mock_send.assert_not_called()

--- a/tests/test_main_health_baseline.py
+++ b/tests/test_main_health_baseline.py
@@ -11,10 +11,13 @@ from site_health import STATUS_OK, STATUS_REGEX_BROKEN, RunOutcome
 
 
 class TestMonitorSiteHealth:
+    """Tests for main._monitor_site_health wiring."""
+
     @patch("main.send_email")
     @patch("main.save_json")
     @patch("main.load_json")
     def test_emails_maintainer_when_regex_broken(self, mock_load, mock_save, mock_send):
+        """A regex-broken outcome records the run and emails the maintainer."""
         mock_load.return_value = ({}, True)
         context = {
             "run_outcomes": [
@@ -36,6 +39,7 @@ class TestMonitorSiteHealth:
     @patch("main.save_json")
     @patch("main.load_json")
     def test_no_email_when_all_ok(self, mock_load, mock_save, mock_send):
+        """All-OK outcomes still record the run but send no maintainer email."""
         mock_load.return_value = ({}, True)
         context = {
             "run_outcomes": [
@@ -52,6 +56,7 @@ class TestMonitorSiteHealth:
     @patch("main.save_json")
     @patch("main.load_json")
     def test_no_outcomes_does_nothing(self, mock_load, mock_save, mock_send):
+        """With no outcomes, no health file is read or written and no email sent."""
         context: dict = {"run_outcomes": []}
 
         main._monitor_site_health(context)
@@ -64,6 +69,7 @@ class TestMonitorSiteHealth:
     @patch("main.save_json")
     @patch("main.load_json")
     def test_never_raises_on_failure(self, mock_load, mock_save, mock_send):
+        """Monitoring swallows errors (e.g. disk failure) and never raises."""
         mock_load.side_effect = OSError("disk gone")
         context = {
             "run_outcomes": [

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -273,6 +273,7 @@ class TestFetchFreshRecipesOutcomes:
     def test_builds_run_outcomes_keyed_by_site_and_course(
         self, mock_urls: Mock, mock_get_html: Mock, mock_scraper: Mock
     ) -> None:
+        """Each (site, course) status becomes a keyed RunOutcome in the result."""
         # No URLs returned -> no recipe HTML fetching/scraping needed
         mock_urls.return_value = (
             [],

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import config
 import recipe_processor
+from site_health import STATUS_OK, STATUS_REGEX_BROKEN, RunOutcome
 
 
 class TestScrapeFlushIntervalConfig:
@@ -229,7 +230,7 @@ class TestFetchFreshRecipesStreaming:
     @patch("recipe_processor.scraper")
     @patch("recipe_processor.get_html")
     @patch("recipe_processor.get_recipe_urls")
-    def test_streams_both_and_returns_two_tuple(
+    def test_streams_both_and_returns_recipes(
         self,
         mock_urls: Mock,
         mock_get_html: Mock,
@@ -237,12 +238,16 @@ class TestFetchFreshRecipesStreaming:
         mock_save: Mock,
         capsys,
     ) -> None:
-        """Mains and sides both stream; returns the 2-tuple and drops the DB repr."""
-        mock_urls.return_value = (["main1"], ["side1"])
+        """Mains and sides both stream; returns recipes + outcomes, drops the DB repr."""
+        mock_urls.return_value = (
+            ["main1"],
+            ["side1"],
+            {"main course": (STATUS_OK, 1), "side dish": (STATUS_OK, 1)},
+        )
         mock_get_html.return_value = "html"
         mock_scraper.side_effect = lambda html, url, failed: {"title": url}
 
-        result = recipe_processor.fetch_fresh_recipes(
+        mains, sides, _ = recipe_processor.fetch_fresh_recipes(
             websites={"site": {"url": "http://x"}},
             unused_main_recipes={},
             unused_side_recipes={},
@@ -251,10 +256,49 @@ class TestFetchFreshRecipesStreaming:
             debug_mode=False,
         )
 
-        mains, sides = result
         assert mains == {"main1": {"title": "main1"}}
         assert sides == {"side1": {"title": "side1"}}
         # Whole-DB repr print is gone (no `unused_main_recipes=` dump).
         out = capsys.readouterr().out
         assert "unused_main_recipes=" not in out
         assert "unused_side_recipes=" not in out
+
+
+class TestFetchFreshRecipesOutcomes:
+    """fetch_fresh_recipes collects per-(site, course) RunOutcome health records."""
+
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    @patch("recipe_processor.get_recipe_urls")
+    def test_builds_run_outcomes_keyed_by_site_and_course(
+        self, mock_urls: Mock, mock_get_html: Mock, mock_scraper: Mock
+    ) -> None:
+        # No URLs returned -> no recipe HTML fetching/scraping needed
+        mock_urls.return_value = (
+            [],
+            [],
+            {"main course": (STATUS_OK, 5), "side dish": (STATUS_REGEX_BROKEN, 0)},
+        )
+        websites = {
+            "Site A": {"main course": "m", "side dish": "s", "regex": "r"},
+        }
+
+        _, _, outcomes = recipe_processor.fetch_fresh_recipes(
+            websites,
+            unused_main_recipes={},
+            unused_side_recipes={},
+            used_recipes={},
+            failed_recipes={},
+            debug_mode=False,
+        )
+
+        assert (
+            RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=5)
+            in outcomes
+        )
+        assert (
+            RunOutcome(
+                key="Site A — side dish", status=STATUS_REGEX_BROKEN, url_count=0
+            )
+            in outcomes
+        )

--- a/tests/test_site_health_baseline.py
+++ b/tests/test_site_health_baseline.py
@@ -1,0 +1,75 @@
+"""Characterization tests for site_health module."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+from site_health import (
+    STATUS_OK,
+    STATUS_REGEX_BROKEN,
+    STATUS_UNREACHABLE,
+    WINDOW_SIZE,
+    RunOutcome,
+    classify_outcome,
+    record_run,
+)
+
+
+class TestClassifyOutcome:
+    def test_unreachable_when_not_reachable(self):
+        assert classify_outcome(reachable=False, url_count=5) == STATUS_UNREACHABLE
+
+    def test_regex_broken_when_reachable_but_zero_urls(self):
+        assert classify_outcome(reachable=True, url_count=0) == STATUS_REGEX_BROKEN
+
+    def test_ok_when_reachable_with_urls(self):
+        assert classify_outcome(reachable=True, url_count=3) == STATUS_OK
+
+
+class TestRecordRun:
+    def test_appends_outcome_to_new_key(self):
+        health: dict = {}
+        outcomes = [
+            RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=4)
+        ]
+
+        record_run(health, outcomes, "2026-05-29")
+
+        assert health == {
+            "Site A — main course": [
+                {"date": "2026-05-29", "status": STATUS_OK, "url_count": 4}
+            ]
+        }
+
+    def test_appends_to_existing_window(self):
+        health = {
+            "Site A — main course": [
+                {"date": "2026-05-22", "status": STATUS_OK, "url_count": 4}
+            ]
+        }
+        outcomes = [
+            RunOutcome(
+                key="Site A — main course", status=STATUS_REGEX_BROKEN, url_count=0
+            )
+        ]
+
+        record_run(health, outcomes, "2026-05-29")
+
+        window = health["Site A — main course"]
+        assert len(window) == 2
+        assert window[-1]["status"] == STATUS_REGEX_BROKEN
+
+    def test_prunes_to_window_size(self):
+        health: dict = {}
+        for day in range(1, WINDOW_SIZE + 2):  # one more than the window holds
+            record_run(
+                health,
+                [RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=1)],
+                f"2026-05-{day:02d}",
+            )
+
+        window = health["Site A — main course"]
+        assert len(window) == WINDOW_SIZE
+        # Oldest (day 1) was pruned; newest (day WINDOW_SIZE+1) retained
+        assert window[0]["date"] == "2026-05-02"
+        assert window[-1]["date"] == f"2026-05-{WINDOW_SIZE + 1:02d}"

--- a/tests/test_site_health_baseline.py
+++ b/tests/test_site_health_baseline.py
@@ -9,8 +9,11 @@ from site_health import (
     STATUS_REGEX_BROKEN,
     STATUS_UNREACHABLE,
     WINDOW_SIZE,
+    HealthReport,
     RunOutcome,
+    build_report,
     classify_outcome,
+    has_something_to_report,
     record_run,
 )
 
@@ -73,3 +76,98 @@ class TestRecordRun:
         # Oldest (day 1) was pruned; newest (day WINDOW_SIZE+1) retained
         assert window[0]["date"] == "2026-05-02"
         assert window[-1]["date"] == f"2026-05-{WINDOW_SIZE + 1:02d}"
+
+
+def _window(*statuses):
+    """Build a window from a sequence of status strings, dated sequentially."""
+    return [
+        {
+            "date": f"2026-05-{i + 1:02d}",
+            "status": s,
+            "url_count": 0 if s != STATUS_OK else 5,
+        }
+        for i, s in enumerate(statuses)
+    ]
+
+
+class TestBuildReport:
+    def test_current_regex_broken_goes_to_broken(self):
+        health = {"Site A — main course": _window(STATUS_OK, STATUS_REGEX_BROKEN)}
+
+        report = build_report(health)
+
+        assert len(report.broken) == 1
+        assert report.broken[0].key == "Site A — main course"
+        assert report.broken[0].status == STATUS_REGEX_BROKEN
+        assert report.unreachable == []
+        assert report.flaky == []
+
+    def test_current_unreachable_goes_to_unreachable(self):
+        health = {"Site B — side dish": _window(STATUS_OK, STATUS_UNREACHABLE)}
+
+        report = build_report(health)
+
+        assert len(report.unreachable) == 1
+        assert report.unreachable[0].key == "Site B — side dish"
+
+    def test_ok_now_but_flaky_goes_to_flaky(self):
+        # Ends OK, but 3 failures within the window -> flaky watch
+        health = {
+            "Site C — main course": _window(
+                STATUS_UNREACHABLE, STATUS_REGEX_BROKEN, STATUS_UNREACHABLE, STATUS_OK
+            )
+        }
+
+        report = build_report(health)
+
+        assert report.broken == []
+        assert report.unreachable == []
+        assert len(report.flaky) == 1
+        assert report.flaky[0].failures == 3
+
+    def test_healthy_site_appears_nowhere(self):
+        health = {"Site D — main course": _window(STATUS_OK, STATUS_OK, STATUS_OK)}
+
+        report = build_report(health)
+
+        assert report.broken == []
+        assert report.unreachable == []
+        assert report.flaky == []
+
+    def test_last_good_is_never_when_window_has_no_ok(self):
+        health = {
+            "Site E — main course": _window(STATUS_REGEX_BROKEN, STATUS_REGEX_BROKEN)
+        }
+
+        report = build_report(health)
+
+        assert report.broken[0].last_good == f"never (in last {WINDOW_SIZE})"
+
+    def test_last_good_reports_most_recent_ok_date(self):
+        health = {"Site F — main course": _window(STATUS_OK, STATUS_REGEX_BROKEN)}
+
+        report = build_report(health)
+
+        assert report.broken[0].last_good == "2026-05-01"
+
+    def test_current_failure_takes_priority_over_flaky(self):
+        health = {
+            "Site G — main course": _window(
+                STATUS_REGEX_BROKEN,
+                STATUS_UNREACHABLE,
+                STATUS_REGEX_BROKEN,
+                STATUS_UNREACHABLE,
+            )
+        }
+        report = build_report(health)
+        assert len(report.unreachable) == 1
+        assert report.flaky == []
+
+
+class TestHasSomethingToReport:
+    def test_false_for_empty_report(self):
+        assert has_something_to_report(HealthReport()) is False
+
+    def test_true_when_broken_present(self):
+        health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
+        assert has_something_to_report(build_report(health)) is True

--- a/tests/test_site_health_baseline.py
+++ b/tests/test_site_health_baseline.py
@@ -15,6 +15,7 @@ from site_health import (
     classify_outcome,
     has_something_to_report,
     record_run,
+    render_health_email,
 )
 
 
@@ -171,3 +172,37 @@ class TestHasSomethingToReport:
     def test_true_when_broken_present(self):
         health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
         assert has_something_to_report(build_report(health)) is True
+
+
+class TestRenderHealthEmail:
+    def test_includes_broken_section_and_key(self):
+        health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
+
+        body = render_health_email(build_report(health))
+
+        assert "Likely broken regex" in body
+        assert "Site A — main course" in body
+        assert body.strip().startswith("<html>")
+
+    def test_omits_empty_sections(self):
+        health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
+
+        body = render_health_email(build_report(health))
+
+        assert "Unreachable" not in body
+        assert "Flaky watch" not in body
+
+    def test_renders_all_three_sections_when_present(self):
+        health = {
+            "Site A — main course": _window(STATUS_REGEX_BROKEN),
+            "Site B — side dish": _window(STATUS_UNREACHABLE),
+            "Site C — main course": _window(
+                STATUS_UNREACHABLE, STATUS_REGEX_BROKEN, STATUS_UNREACHABLE, STATUS_OK
+            ),
+        }
+
+        body = render_health_email(build_report(health))
+
+        assert "Likely broken regex" in body
+        assert "Unreachable" in body
+        assert "Flaky watch" in body

--- a/tests/test_site_health_baseline.py
+++ b/tests/test_site_health_baseline.py
@@ -20,18 +20,26 @@ from site_health import (
 
 
 class TestClassifyOutcome:
+    """Test classify_outcome status mapping."""
+
     def test_unreachable_when_not_reachable(self):
+        """An unreachable page classifies as UNREACHABLE regardless of url_count."""
         assert classify_outcome(reachable=False, url_count=5) == STATUS_UNREACHABLE
 
     def test_regex_broken_when_reachable_but_zero_urls(self):
+        """A reachable page with zero URLs classifies as REGEX_BROKEN."""
         assert classify_outcome(reachable=True, url_count=0) == STATUS_REGEX_BROKEN
 
     def test_ok_when_reachable_with_urls(self):
+        """A reachable page with URLs classifies as OK."""
         assert classify_outcome(reachable=True, url_count=3) == STATUS_OK
 
 
 class TestRecordRun:
+    """Test record_run window persistence and pruning."""
+
     def test_appends_outcome_to_new_key(self):
+        """Recording a run for a new key creates a single-entry window."""
         health: dict = {}
         outcomes = [
             RunOutcome(key="Site A — main course", status=STATUS_OK, url_count=4)
@@ -46,6 +54,7 @@ class TestRecordRun:
         }
 
     def test_appends_to_existing_window(self):
+        """Recording a run appends to an existing key's window."""
         health = {
             "Site A — main course": [
                 {"date": "2026-05-22", "status": STATUS_OK, "url_count": 4}
@@ -64,6 +73,7 @@ class TestRecordRun:
         assert window[-1]["status"] == STATUS_REGEX_BROKEN
 
     def test_prunes_to_window_size(self):
+        """The window is pruned to WINDOW_SIZE, dropping the oldest entries."""
         health: dict = {}
         for day in range(1, WINDOW_SIZE + 2):  # one more than the window holds
             record_run(
@@ -92,7 +102,10 @@ def _window(*statuses):
 
 
 class TestBuildReport:
+    """Test build_report categorization of windows."""
+
     def test_current_regex_broken_goes_to_broken(self):
+        """A currently regex-broken site lands in the broken section."""
         health = {"Site A — main course": _window(STATUS_OK, STATUS_REGEX_BROKEN)}
 
         report = build_report(health)
@@ -104,6 +117,7 @@ class TestBuildReport:
         assert report.flaky == []
 
     def test_current_unreachable_goes_to_unreachable(self):
+        """A currently unreachable site lands in the unreachable section."""
         health = {"Site B — side dish": _window(STATUS_OK, STATUS_UNREACHABLE)}
 
         report = build_report(health)
@@ -112,6 +126,7 @@ class TestBuildReport:
         assert report.unreachable[0].key == "Site B — side dish"
 
     def test_ok_now_but_flaky_goes_to_flaky(self):
+        """A site that is OK now but failed repeatedly lands in flaky watch."""
         # Ends OK, but 3 failures within the window -> flaky watch
         health = {
             "Site C — main course": _window(
@@ -127,6 +142,7 @@ class TestBuildReport:
         assert report.flaky[0].failures == 3
 
     def test_healthy_site_appears_nowhere(self):
+        """A consistently healthy site appears in no report section."""
         health = {"Site D — main course": _window(STATUS_OK, STATUS_OK, STATUS_OK)}
 
         report = build_report(health)
@@ -136,6 +152,7 @@ class TestBuildReport:
         assert report.flaky == []
 
     def test_last_good_is_never_when_window_has_no_ok(self):
+        """last_good reads 'never' when the window contains no OK run."""
         health = {
             "Site E — main course": _window(STATUS_REGEX_BROKEN, STATUS_REGEX_BROKEN)
         }
@@ -145,6 +162,7 @@ class TestBuildReport:
         assert report.broken[0].last_good == f"never (in last {WINDOW_SIZE})"
 
     def test_last_good_reports_most_recent_ok_date(self):
+        """last_good reports the date of the most recent OK run."""
         health = {"Site F — main course": _window(STATUS_OK, STATUS_REGEX_BROKEN)}
 
         report = build_report(health)
@@ -152,6 +170,7 @@ class TestBuildReport:
         assert report.broken[0].last_good == "2026-05-01"
 
     def test_current_failure_takes_priority_over_flaky(self):
+        """A current failure is reported as failing rather than merely flaky."""
         health = {
             "Site G — main course": _window(
                 STATUS_REGEX_BROKEN,
@@ -166,16 +185,23 @@ class TestBuildReport:
 
 
 class TestHasSomethingToReport:
+    """Test has_something_to_report truthiness."""
+
     def test_false_for_empty_report(self):
+        """An empty report has nothing to report."""
         assert has_something_to_report(HealthReport()) is False
 
     def test_true_when_broken_present(self):
+        """A report with a broken entry has something to report."""
         health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
         assert has_something_to_report(build_report(health)) is True
 
 
 class TestRenderHealthEmail:
+    """Test render_health_email HTML output."""
+
     def test_includes_broken_section_and_key(self):
+        """The rendered email includes the broken section and the affected key."""
         health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
 
         body = render_health_email(build_report(health))
@@ -185,6 +211,7 @@ class TestRenderHealthEmail:
         assert body.strip().startswith("<html>")
 
     def test_omits_empty_sections(self):
+        """Sections with no entries are omitted from the rendered email."""
         health = {"Site A — main course": _window(STATUS_REGEX_BROKEN)}
 
         body = render_health_email(build_report(health))
@@ -193,6 +220,7 @@ class TestRenderHealthEmail:
         assert "Flaky watch" not in body
 
     def test_renders_all_three_sections_when_present(self):
+        """All three sections render when broken, unreachable, and flaky exist."""
         health = {
             "Site A — main course": _window(STATUS_REGEX_BROKEN),
             "Site B — side dish": _window(STATUS_UNREACHABLE),

--- a/tests/test_web_scraper_baseline.py
+++ b/tests/test_web_scraper_baseline.py
@@ -76,40 +76,70 @@ class TestGetHtml:
 class TestGetRecipeUrls:
     """Test get_recipe_urls function behavior."""
 
-    @patch("web_scraper.get_html")
-    def test_extracts_urls_from_both_pages(self, mock_get_html):
-        """Test URL extraction from main and side pages."""
-        mock_get_html.side_effect = [
-            '<a href="https://example.com/recipe1">',
-            '<a href="https://example.com/side1">',
+    @patch("web_scraper.fetch_page")
+    def test_extracts_urls_and_reports_ok_status(self, mock_fetch):
+        mock_fetch.side_effect = [
+            PageResult(
+                reachable=True,
+                status_code=200,
+                html='<a href="https://example.com/recipe1">',
+            ),
+            PageResult(
+                reachable=True,
+                status_code=200,
+                html='<a href="https://example.com/side1">',
+            ),
         ]
-
         selection = {
             "main course": "https://example.com/mains",
             "side dish": "https://example.com/sides",
             "regex": r'href="(https://example.com/\w+)"',
         }
 
-        main_urls, side_urls = get_recipe_urls(selection, debug_mode=False)
+        main_urls, side_urls, statuses = get_recipe_urls(selection, debug_mode=False)
 
         assert "https://example.com/recipe1" in main_urls
         assert "https://example.com/side1" in side_urls
+        assert statuses["main course"] == ("OK", 1)
+        assert statuses["side dish"] == ("OK", 1)
 
-    @patch("web_scraper.get_html")
-    def test_returns_empty_lists_on_no_match(self, mock_get_html):
-        """Test returns empty lists when regex doesn't match."""
-        mock_get_html.side_effect = ["no matches here", "no matches here"]
-
+    @patch("web_scraper.fetch_page")
+    def test_reachable_with_no_matches_reports_regex_broken(self, mock_fetch):
+        mock_fetch.side_effect = [
+            PageResult(reachable=True, status_code=200, html="no matches here"),
+            PageResult(reachable=True, status_code=200, html="no matches here"),
+        ]
         selection = {
             "main course": "url1",
             "side dish": "url2",
             "regex": r'href="(https://nomatch.com/\w+)"',
         }
 
-        main_urls, side_urls = get_recipe_urls(selection)
+        main_urls, side_urls, statuses = get_recipe_urls(selection)
 
         assert main_urls == []
         assert side_urls == []
+        assert statuses["main course"] == ("REGEX_BROKEN", 0)
+        assert statuses["side dish"] == ("REGEX_BROKEN", 0)
+
+    @patch("web_scraper.fetch_page")
+    def test_unreachable_page_reports_unreachable_status(self, mock_fetch):
+        mock_fetch.side_effect = [
+            PageResult(reachable=False, status_code=None, html=""),
+            PageResult(reachable=False, status_code=503, html=""),
+        ]
+        selection = {
+            "main course": "url1",
+            "side dish": "url2",
+            "regex": r'href="(\S+)"',
+        }
+
+        main_urls, side_urls, statuses = get_recipe_urls(selection)
+
+        assert main_urls == []
+        assert side_urls == []
+        assert statuses["main course"] == ("UNREACHABLE", 0)
+        assert statuses["side dish"] == ("UNREACHABLE", 0)
 
 
 class TestCleanupRecipeUrls:

--- a/tests/test_web_scraper_baseline.py
+++ b/tests/test_web_scraper_baseline.py
@@ -78,6 +78,7 @@ class TestGetRecipeUrls:
 
     @patch("web_scraper.fetch_page")
     def test_extracts_urls_and_reports_ok_status(self, mock_fetch):
+        """Matched URLs are extracted and each course reports an OK status."""
         mock_fetch.side_effect = [
             PageResult(
                 reachable=True,
@@ -105,6 +106,7 @@ class TestGetRecipeUrls:
 
     @patch("web_scraper.fetch_page")
     def test_reachable_with_no_matches_reports_regex_broken(self, mock_fetch):
+        """A reachable page yielding zero matches reports REGEX_BROKEN."""
         mock_fetch.side_effect = [
             PageResult(reachable=True, status_code=200, html="no matches here"),
             PageResult(reachable=True, status_code=200, html="no matches here"),
@@ -124,6 +126,7 @@ class TestGetRecipeUrls:
 
     @patch("web_scraper.fetch_page")
     def test_unreachable_page_reports_unreachable_status(self, mock_fetch):
+        """An unreachable page reports UNREACHABLE and yields no URLs."""
         mock_fetch.side_effect = [
             PageResult(reachable=False, status_code=None, html=""),
             PageResult(reachable=False, status_code=503, html=""),
@@ -347,6 +350,7 @@ class TestFetchPage:
 
     @patch("web_scraper.requests.get")
     def test_reachable_on_200_with_body(self, mock_get: Mock) -> None:
+        """A 200 response with a non-empty body is classified as reachable."""
         mock_response = Mock()
         mock_response.text = "<html>content</html>"
         mock_response.status_code = 200
@@ -362,6 +366,7 @@ class TestFetchPage:
 
     @patch("web_scraper.requests.get")
     def test_unreachable_on_200_with_empty_body(self, mock_get: Mock) -> None:
+        """A 200 response with a blank body is classified as unreachable."""
         mock_response = Mock()
         mock_response.text = "   "
         mock_response.status_code = 200
@@ -376,6 +381,7 @@ class TestFetchPage:
 
     @patch("web_scraper.requests.get")
     def test_unreachable_on_non_200(self, mock_get: Mock) -> None:
+        """A non-200 status code is classified as unreachable."""
         mock_response = Mock()
         mock_response.text = "Forbidden"
         mock_response.status_code = 403
@@ -390,6 +396,7 @@ class TestFetchPage:
 
     @patch("web_scraper.requests.get")
     def test_unreachable_on_timeout(self, mock_get: Mock) -> None:
+        """A request timeout is classified as unreachable with no status code."""
         mock_get.side_effect = requests.exceptions.Timeout()
 
         result = fetch_page("https://example.com")
@@ -398,6 +405,7 @@ class TestFetchPage:
 
     @patch("web_scraper.requests.get")
     def test_unreachable_on_connection_error(self, mock_get: Mock) -> None:
+        """A connection error is classified as unreachable with no status code."""
         mock_get.side_effect = requests.exceptions.ConnectionError()
 
         result = fetch_page("https://example.com")

--- a/tests/test_web_scraper_baseline.py
+++ b/tests/test_web_scraper_baseline.py
@@ -7,7 +7,14 @@ from unittest.mock import Mock, patch
 import requests
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
-from web_scraper import cleanup_recipe_urls, get_html, get_recipe_urls, scraper
+from web_scraper import (
+    PageResult,
+    cleanup_recipe_urls,
+    fetch_page,
+    get_html,
+    get_recipe_urls,
+    scraper,
+)
 
 
 class TestGetHtml:
@@ -303,3 +310,67 @@ class TestScrapeRecipe:
         assert result is None
         assert "https://example.com/recipe" in failed_recipes
         assert "Scraping error" in failed_recipes["https://example.com/recipe"]
+
+
+class TestFetchPage:
+    """Test fetch_page reachability classification."""
+
+    @patch("web_scraper.requests.get")
+    def test_reachable_on_200_with_body(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.text = "<html>content</html>"
+        mock_response.status_code = 200
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_get.return_value = mock_response
+
+        result = fetch_page("https://example.com")
+
+        assert result == PageResult(
+            reachable=True, status_code=200, html="<html>content</html>"
+        )
+
+    @patch("web_scraper.requests.get")
+    def test_unreachable_on_200_with_empty_body(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.text = "   "
+        mock_response.status_code = 200
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_get.return_value = mock_response
+
+        result = fetch_page("https://example.com")
+
+        assert result.reachable is False
+        assert result.status_code == 200
+
+    @patch("web_scraper.requests.get")
+    def test_unreachable_on_non_200(self, mock_get: Mock) -> None:
+        mock_response = Mock()
+        mock_response.text = "Forbidden"
+        mock_response.status_code = 403
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=False)
+        mock_get.return_value = mock_response
+
+        result = fetch_page("https://example.com")
+
+        assert result.reachable is False
+        assert result.status_code == 403
+
+    @patch("web_scraper.requests.get")
+    def test_unreachable_on_timeout(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        result = fetch_page("https://example.com")
+
+        assert result == PageResult(reachable=False, status_code=None, html="")
+
+    @patch("web_scraper.requests.get")
+    def test_unreachable_on_connection_error(self, mock_get: Mock) -> None:
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+
+        result = fetch_page("https://example.com")
+
+        assert result.reachable is False
+        assert result.status_code is None

--- a/web_scraper.py
+++ b/web_scraper.py
@@ -1,6 +1,7 @@
 """Web scraping utilities for fetching and parsing recipes."""
 
 import re
+from dataclasses import dataclass
 
 import requests
 from recipe_scrapers import scrape_html
@@ -14,6 +15,35 @@ from config import (
     URL_FIX_DOMAIN,
     URL_FIX_PREFIX,
 )
+
+
+@dataclass(frozen=True)
+class PageResult:
+    """Outcome of fetching a listing page, for health monitoring.
+
+    reachable is True only for an HTTP 200 with a non-empty body.
+    """
+
+    reachable: bool
+    status_code: int | None
+    html: str
+
+
+def fetch_page(url: str, debug_mode: bool = False) -> PageResult:
+    """Fetch a listing page, reporting reachability for health monitoring."""
+    timeout = DEBUG_TIMEOUT if debug_mode else NORMAL_TIMEOUT
+    try:
+        with requests.get(url, headers=HEADERS, timeout=timeout) as response:
+            body = response.text
+            reachable = response.status_code == 200 and bool(body.strip())
+            return PageResult(
+                reachable=reachable,
+                status_code=response.status_code,
+                html=body,
+            )
+    except (requests.exceptions.Timeout, requests.exceptions.ConnectionError):
+        print(f"{url} unreachable. Skipping")
+        return PageResult(reachable=False, status_code=None, html="")
 
 
 def get_html(website: str, debug_mode: bool = False) -> str:

--- a/web_scraper.py
+++ b/web_scraper.py
@@ -15,6 +15,7 @@ from config import (
     URL_FIX_DOMAIN,
     URL_FIX_PREFIX,
 )
+from site_health import classify_outcome
 
 
 @dataclass(frozen=True)
@@ -59,20 +60,29 @@ def get_html(website: str, debug_mode: bool = False) -> str:
         return ""
 
 
-def get_recipe_urls(selection: dict, debug_mode: bool = False) -> tuple[list, list]:
-    """Get individual recipe URLs from website.
+def get_recipe_urls(
+    selection: dict, debug_mode: bool = False
+) -> tuple[list[str], list[str], dict[str, tuple[str, int]]]:
+    """Get individual recipe URLs from a website's listing pages.
 
-    Returns a tuple with URLs for entrées and side dishes.
+    Returns (main_urls, side_urls, statuses) where statuses maps each course
+    ("main course" / "side dish") to (status, raw_match_count) for health
+    monitoring. Status is derived from the raw regex match count, before
+    cleanup_recipe_urls filters excluded URLs, so an all-filtered page is not
+    mistaken for a broken regex.
     """
-    main_html = get_html(selection["main course"], debug_mode)
-    side_html = get_html(selection["side dish"], debug_mode)
+    url_lists: dict[str, list[str]] = {}
+    statuses: dict[str, tuple[str, int]] = {}
 
-    main_urls = re.findall(selection["regex"], main_html)
-    side_urls = re.findall(selection["regex"], side_html)
+    for course in ("main course", "side dish"):
+        page = fetch_page(selection[course], debug_mode)
+        urls = re.findall(selection["regex"], page.html)
+        match_count = len(urls)
+        cleanup_recipe_urls(urls)
+        statuses[course] = (classify_outcome(page.reachable, match_count), match_count)
+        url_lists[course] = urls
 
-    cleanup_recipe_urls(main_urls)
-    cleanup_recipe_urls(side_urls)
-    return main_urls, side_urls
+    return url_lists["main course"], url_lists["side dish"], statuses
 
 
 def cleanup_recipe_urls(urls: list[str]) -> None:


### PR DESCRIPTION
## Summary
- Detects when a recipe site's URL-extraction regex silently breaks, distinguishing it from the site being unreachable (HTTP 200 + non-empty body but 0 regex matches → likely broken regex; timeout/connection/non-200 → unreachable).
- Tracks per-`(site, course)` outcomes over an 8-run rolling window in `site_health.json` (a committed JSON "database", matching the existing `*_recipes.json` pattern).
- Emails the maintainer (`SENDER`) a summary **only when there's something to report** — broken regex, unreachable, or a flaky site (≥3 failures of last 8) — with three sections. Wrapped in try/except so monitoring never breaks the unattended recipe run; skipped in debug mode.

## Changes
- New `site_health.py` (pure logic: classify, rolling-window record, report build, HTML render).
- `web_scraper.fetch_page` (reachability-aware) + `get_recipe_urls` returns per-course status.
- `recipe_processor` collects `RunOutcome`s; `main._monitor_site_health` records + emails.

## Test Plan
- [x] 102 tests pass (`pytest`)
- [x] `site_health.py` / `main.py` / `config.py` mypy-strict clean; ruff + black clean

## Note
Touches `main.py`'s import block in the same region as the seasonal-AI PR — trivial manual merge if both land (no logic conflict).

## Summary by Sourcery

Add site health monitoring that classifies per-site scraping outcomes, records them over time, and notifies the maintainer when issues are detected.

New Features:
- Introduce site_health module to classify scrape outcomes, maintain rolling health windows, and generate HTML email reports for problematic or flaky sites.
- Track per-(site, course) scrape outcomes during recipe fetching and surface them to the main flow for monitoring and alerting.
- Extend configuration with filenames and email subject for persisted site health data and maintainer alerts.

Enhancements:
- Update web_scraper to provide reachability-aware page fetching and per-course status metadata for regex extraction, enabling health classification without affecting core scraping behavior.

Tests:
- Add baseline tests for site_health behavior, email rendering, and flakiness logic.
- Add tests for main._monitor_site_health wiring and behavior, ensuring persistence and email notifications behave as expected without breaking the main run.
- Add tests for recipe_processor to verify correct collection of per-site run outcomes and for web_scraper to validate reachability classification and status reporting.