### PR TITLE
fix: stream recipe scraping to bound memory (Pi OOM)

### DIFF
--- a/config.py
+++ b/config.py
@@ -19,6 +19,7 @@ __all__ = [
     "UNUSED_MAINS_FILENAME",
     "UNUSED_SIDES_FILENAME",
     "FAILED_FILENAME",
+    "SCRAPE_FLUSH_INTERVAL",
     "USED_FILENAME",
     "FILE_AGE_THRESHOLD",
     "HEADERS",
@@ -172,3 +173,6 @@ VEGGIES: Final[tuple[str, ...]] = (
     "yam",
     "zucchini",
 )
+
+# How often (in scraped URLs) to flush recipe progress to disk during scraping.
+SCRAPE_FLUSH_INTERVAL: Final[int] = 100

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -2,7 +2,30 @@
 
 from tqdm import tqdm
 
+from config import (
+    FAILED_FILENAME,
+    SCRAPE_FLUSH_INTERVAL,
+    UNUSED_MAINS_FILENAME,
+    UNUSED_SIDES_FILENAME,
+)
+from file_utils import save_json
 from web_scraper import get_html, get_recipe_urls, scraper
+
+
+def _flush_scrape_progress(
+    target_filename: str,
+    target_recipes: dict[str, dict],
+    failed_recipes: dict[str, str],
+    debug_mode: bool,
+) -> None:
+    """Persist the active stream's recipes + the failed-recipes skip-list.
+
+    No-op in debug mode (debug must never write the database files).
+    """
+    if debug_mode:
+        return
+    save_json(target_filename, target_recipes)
+    save_json(FAILED_FILENAME, failed_recipes)
 
 
 def fetch_fresh_recipes(

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -28,6 +28,35 @@ def _flush_scrape_progress(
     save_json(FAILED_FILENAME, failed_recipes)
 
 
+def _scrape_urls_streaming(
+    urls: list[str],
+    target_recipes: dict[str, dict],
+    target_filename: str,
+    failed_recipes: dict[str, str],
+    debug_mode: bool,
+    flush_interval: int = SCRAPE_FLUSH_INTERVAL,
+) -> None:
+    """Fetch + scrape one page at a time, routing results and flushing periodically.
+
+    Never holds more than one page's HTML in memory. Mutates target_recipes and
+    failed_recipes in place. Flushes to disk every `flush_interval` processed URLs
+    (and once at the end), except in debug mode.
+    """
+    processed = 0
+    for url in tqdm(urls):
+        html = get_html(url, debug_mode)
+        recipe = scraper(html, url, failed_recipes)
+        del html  # free immediately — peak memory is one page, not all pages
+        if recipe is not None:
+            target_recipes[url] = recipe
+        processed += 1
+        if processed % flush_interval == 0:
+            _flush_scrape_progress(
+                target_filename, target_recipes, failed_recipes, debug_mode
+            )
+    _flush_scrape_progress(target_filename, target_recipes, failed_recipes, debug_mode)
+
+
 def fetch_fresh_recipes(
     websites: dict[str, dict[str, str]],
     unused_main_recipes: dict,

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -94,29 +94,26 @@ def fetch_fresh_recipes(
     side_urls = [url for url in side_urls if url not in failed_recipes]
     print(f"main {len(main_urls)} new\nside {len(side_urls)} new")
 
-    # GET HTML FOR EACH RECIPE URL
-    main_htmls, side_htmls = {}, {}
-    print(f"Getting HTML for {len(main_urls)} main dish recipe pages")
-    for url in tqdm(main_urls):
-        main_htmls[url] = get_html(url, debug_mode)
-    print(f"Getting HTML for {len(side_urls)} side dish recipe pages")
-    for url in tqdm(side_urls):
-        side_htmls[url] = get_html(url, debug_mode)
-
-    # USE HHURSEV'S RECIPE SCRAPER
-    if len(main_htmls) > 0:
-        print("Scraping main course HTMLs")
-        for url, html in (item for item in tqdm(main_htmls.items())):
-            recipe_elements = scraper(html, url, failed_recipes)
-            if recipe_elements is not None:
-                unused_main_recipes[url] = recipe_elements
-    if len(side_htmls) > 0:
-        print("Scraping side dish HTMLs")
-        for url, html in (item for item in tqdm(side_htmls.items())):
-            recipe_elements = scraper(html, url, failed_recipes)
-            if recipe_elements is not None:
-                unused_side_recipes[url] = recipe_elements
-    print(f"main {len(unused_main_recipes)} {unused_main_recipes=}")
-    print(f"side {len(unused_side_recipes)} {unused_side_recipes=}")
+    # STREAM: fetch + scrape one page at a time, flushing progress to disk.
+    print(f"Scraping {len(main_urls)} main dish recipe pages")
+    _scrape_urls_streaming(
+        main_urls,
+        unused_main_recipes,
+        UNUSED_MAINS_FILENAME,
+        failed_recipes,
+        debug_mode,
+    )
+    print(f"Scraping {len(side_urls)} side dish recipe pages")
+    _scrape_urls_streaming(
+        side_urls,
+        unused_side_recipes,
+        UNUSED_SIDES_FILENAME,
+        failed_recipes,
+        debug_mode,
+    )
+    print(
+        f"main {len(unused_main_recipes)} new total, "
+        f"side {len(unused_side_recipes)} new total"
+    )
 
     return unused_main_recipes, unused_side_recipes

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -42,14 +42,12 @@ def _scrape_urls_streaming(
     failed_recipes in place. Flushes to disk every `flush_interval` processed URLs
     (and once at the end), except in debug mode.
     """
-    processed = 0
-    for url in tqdm(urls):
+    for processed, url in enumerate(tqdm(urls), start=1):
         html = get_html(url, debug_mode)
         recipe = scraper(html, url, failed_recipes)
         del html  # free immediately — peak memory is one page, not all pages
         if recipe is not None:
             target_recipes[url] = recipe
-        processed += 1
         if processed % flush_interval == 0:
             _flush_scrape_progress(
                 target_filename, target_recipes, failed_recipes, debug_mode

--- a/recipe_processor.py
+++ b/recipe_processor.py
@@ -43,11 +43,17 @@ def _scrape_urls_streaming(
     (and once at the end), except in debug mode.
     """
     for processed, url in enumerate(tqdm(urls), start=1):
-        html = get_html(url, debug_mode)
-        recipe = scraper(html, url, failed_recipes)
-        del html  # free immediately — peak memory is one page, not all pages
-        if recipe is not None:
-            target_recipes[url] = recipe
+        try:
+            html = get_html(url, debug_mode)
+            recipe = scraper(html, url, failed_recipes)
+            del html  # free immediately — peak memory is one page, not all pages
+            if recipe is not None:
+                target_recipes[url] = recipe
+        # Unattended on the Pi: one bad URL (e.g. a network error escaping
+        # get_html) must not abort the whole stream or lose flushed progress.
+        except Exception as exc:
+            print(f"Error scraping {url}: {exc}. Skipping.")
+            failed_recipes[url] = f"FAILS due to: {exc}"
         if processed % flush_interval == 0:
             _flush_scrape_progress(
                 target_filename, target_recipes, failed_recipes, debug_mode

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -1,0 +1,20 @@
+"""Characterization tests for recipe_processor streaming scrape - locks in behavior."""
+
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import config
+import recipe_processor
+
+
+class TestScrapeFlushIntervalConfig:
+    """Test the SCRAPE_FLUSH_INTERVAL config constant."""
+
+    def test_flush_interval_default_value(self) -> None:
+        assert config.SCRAPE_FLUSH_INTERVAL == 100
+
+    def test_flush_interval_exported(self) -> None:
+        assert "SCRAPE_FLUSH_INTERVAL" in config.__all__

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -153,3 +153,40 @@ class TestScrapeUrlsStreaming:
         )
 
         mock_save.assert_not_called()
+
+
+class TestFetchFreshRecipesStreaming:
+    """End-to-end: fetch_fresh_recipes streams mains then sides, no batch dicts."""
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    @patch("recipe_processor.get_recipe_urls")
+    def test_streams_both_and_returns_two_tuple(
+        self,
+        mock_urls: Mock,
+        mock_get_html: Mock,
+        mock_scraper: Mock,
+        mock_save: Mock,
+        capsys,
+    ) -> None:
+        mock_urls.return_value = (["main1"], ["side1"])
+        mock_get_html.return_value = "html"
+        mock_scraper.side_effect = lambda html, url, failed: {"title": url}
+
+        result = recipe_processor.fetch_fresh_recipes(
+            websites={"site": {"url": "http://x"}},
+            unused_main_recipes={},
+            unused_side_recipes={},
+            used_recipes={},
+            failed_recipes={},
+            debug_mode=False,
+        )
+
+        mains, sides = result
+        assert mains == {"main1": {"title": "main1"}}
+        assert sides == {"side1": {"title": "side1"}}
+        # Whole-DB repr print is gone (no `unused_main_recipes=` dump).
+        out = capsys.readouterr().out
+        assert "unused_main_recipes=" not in out
+        assert "unused_side_recipes=" not in out

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -4,6 +4,8 @@ import sys
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import requests
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import config
@@ -14,9 +16,11 @@ class TestScrapeFlushIntervalConfig:
     """Test the SCRAPE_FLUSH_INTERVAL config constant."""
 
     def test_flush_interval_default_value(self) -> None:
+        """SCRAPE_FLUSH_INTERVAL defaults to 100 processed URLs."""
         assert config.SCRAPE_FLUSH_INTERVAL == 100
 
     def test_flush_interval_exported(self) -> None:
+        """SCRAPE_FLUSH_INTERVAL is part of the config public API."""
         assert "SCRAPE_FLUSH_INTERVAL" in config.__all__
 
 
@@ -25,20 +29,22 @@ class TestFlushScrapeProgress:
 
     @patch("recipe_processor.save_json")
     def test_flush_writes_target_and_failed(self, mock_save: Mock) -> None:
+        """A flush persists the active stream's file plus the failed-recipes file."""
         target = {"u1": {"title": "a"}}
         failed = {"bad": "reason"}
         recipe_processor._flush_scrape_progress(
-            "unused_mains_recipes.json", target, failed, debug_mode=False
+            config.UNUSED_MAINS_FILENAME, target, failed, debug_mode=False
         )
         # Writes exactly the active stream's file + the failed-recipes file.
         assert mock_save.call_count == 2
-        mock_save.assert_any_call("unused_mains_recipes.json", target)
+        mock_save.assert_any_call(config.UNUSED_MAINS_FILENAME, target)
         mock_save.assert_any_call(config.FAILED_FILENAME, failed)
 
     @patch("recipe_processor.save_json")
     def test_flush_is_noop_in_debug_mode(self, mock_save: Mock) -> None:
+        """Debug mode never writes the database files."""
         recipe_processor._flush_scrape_progress(
-            "unused_mains_recipes.json", {"u1": {}}, {}, debug_mode=True
+            config.UNUSED_MAINS_FILENAME, {"u1": {}}, {}, debug_mode=True
         )
         mock_save.assert_not_called()
 
@@ -52,6 +58,7 @@ class TestScrapeUrlsStreaming:
     def test_routes_recipes_and_skips_none(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """Scraped recipes land in the target dict; failed (None) scrapes do not."""
         mock_get_html.side_effect = lambda url, dbg: f"html-{url}"
         # u2 fails to scrape (returns None); u1, u3 succeed.
         mock_scraper.side_effect = lambda html, url, failed: (
@@ -61,7 +68,7 @@ class TestScrapeUrlsStreaming:
         failed: dict[str, str] = {}
 
         recipe_processor._scrape_urls_streaming(
-            ["u1", "u2", "u3"], target, "unused_mains_recipes.json", failed, False
+            ["u1", "u2", "u3"], target, config.UNUSED_MAINS_FILENAME, failed, False
         )
 
         assert target == {"u1": {"title": "u1"}, "u3": {"title": "u3"}}
@@ -73,12 +80,13 @@ class TestScrapeUrlsStreaming:
     def test_streams_one_call_per_url(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """Each URL triggers exactly one get_html and one scraper call (no batching)."""
         mock_get_html.return_value = "html"
         mock_scraper.return_value = {"title": "x"}
         urls = [f"u{i}" for i in range(7)]
 
         recipe_processor._scrape_urls_streaming(
-            urls, {}, "unused_mains_recipes.json", {}, False
+            urls, {}, config.UNUSED_MAINS_FILENAME, {}, False
         )
 
         assert mock_get_html.call_count == 7
@@ -90,13 +98,14 @@ class TestScrapeUrlsStreaming:
     def test_periodic_flush_plus_final(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """Progress flushes every flush_interval URLs plus once at the end."""
         mock_get_html.return_value = "html"
         mock_scraper.return_value = {"title": "x"}
 
         recipe_processor._scrape_urls_streaming(
             [f"u{i}" for i in range(5)],
             {},
-            "unused_mains_recipes.json",
+            config.UNUSED_MAINS_FILENAME,
             {},
             False,
             flush_interval=2,
@@ -107,7 +116,7 @@ class TestScrapeUrlsStreaming:
         target_saves = [
             c
             for c in mock_save.call_args_list
-            if c.args[0] == "unused_mains_recipes.json"
+            if c.args[0] == config.UNUSED_MAINS_FILENAME
         ]
         failed_saves = [
             c for c in mock_save.call_args_list if c.args[0] == config.FAILED_FILENAME
@@ -121,17 +130,18 @@ class TestScrapeUrlsStreaming:
     def test_final_flush_always_happens(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """A single final flush occurs even when the interval is never hit."""
         mock_get_html.return_value = "html"
         mock_scraper.return_value = {"title": "x"}
 
         recipe_processor._scrape_urls_streaming(
-            ["only"], {}, "unused_mains_recipes.json", {}, False, flush_interval=100
+            ["only"], {}, config.UNUSED_MAINS_FILENAME, {}, False, flush_interval=100
         )
 
         target_saves = [
             c
             for c in mock_save.call_args_list
-            if c.args[0] == "unused_mains_recipes.json"
+            if c.args[0] == config.UNUSED_MAINS_FILENAME
         ]
         assert len(target_saves) == 1
 
@@ -141,13 +151,14 @@ class TestScrapeUrlsStreaming:
     def test_debug_mode_never_flushes(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """Debug mode never persists progress, even past the flush interval."""
         mock_get_html.return_value = "html"
         mock_scraper.return_value = {"title": "x"}
 
         recipe_processor._scrape_urls_streaming(
             [f"u{i}" for i in range(5)],
             {},
-            "unused_mains_recipes.json",
+            config.UNUSED_MAINS_FILENAME,
             {},
             True,
             flush_interval=2,
@@ -161,8 +172,9 @@ class TestScrapeUrlsStreaming:
     def test_empty_url_list_still_flushes_once(
         self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
     ) -> None:
+        """An empty URL list scrapes nothing but still does one final flush."""
         recipe_processor._scrape_urls_streaming(
-            [], {}, "unused_mains_recipes.json", {}, False
+            [], {}, config.UNUSED_MAINS_FILENAME, {}, False
         )
 
         mock_get_html.assert_not_called()
@@ -170,13 +182,44 @@ class TestScrapeUrlsStreaming:
         target_saves = [
             c
             for c in mock_save.call_args_list
-            if c.args[0] == "unused_mains_recipes.json"
+            if c.args[0] == config.UNUSED_MAINS_FILENAME
         ]
         failed_saves = [
             c for c in mock_save.call_args_list if c.args[0] == config.FAILED_FILENAME
         ]
         assert len(target_saves) == 1
         assert len(failed_saves) == 1
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_get_html_error_on_one_url_does_not_abort_stream(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        """A get_html failure on one URL is recorded and the stream continues."""
+
+        def _get_html(url: str, dbg: bool) -> str:
+            if url == "u2":
+                raise requests.exceptions.ConnectionError("boom")
+            return "html"
+
+        mock_get_html.side_effect = _get_html
+        mock_scraper.side_effect = lambda html, url, failed: {"title": url}
+        target: dict[str, dict] = {}
+        failed: dict[str, str] = {}
+
+        recipe_processor._scrape_urls_streaming(
+            ["u1", "u2", "u3"], target, config.UNUSED_MAINS_FILENAME, failed, False
+        )
+
+        # u1 and u3 are still scraped despite u2 raising mid-stream.
+        assert target == {"u1": {"title": "u1"}, "u3": {"title": "u3"}}
+        # The failing URL is recorded so it is skipped on future runs.
+        assert "u2" in failed
+        # The final flush still ran.
+        assert any(
+            c.args[0] == config.UNUSED_MAINS_FILENAME for c in mock_save.call_args_list
+        )
 
 
 class TestFetchFreshRecipesStreaming:
@@ -194,6 +237,7 @@ class TestFetchFreshRecipesStreaming:
         mock_save: Mock,
         capsys,
     ) -> None:
+        """Mains and sides both stream; returns the 2-tuple and drops the DB repr."""
         mock_urls.return_value = (["main1"], ["side1"])
         mock_get_html.return_value = "html"
         mock_scraper.side_effect = lambda html, url, failed: {"title": url}

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -41,3 +41,115 @@ class TestFlushScrapeProgress:
             "unused_mains_recipes.json", {"u1": {}}, {}, debug_mode=True
         )
         mock_save.assert_not_called()
+
+
+class TestScrapeUrlsStreaming:
+    """Test the _scrape_urls_streaming one-page-at-a-time loop."""
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_routes_recipes_and_skips_none(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        mock_get_html.side_effect = lambda url, dbg: f"html-{url}"
+        # u2 fails to scrape (returns None); u1, u3 succeed.
+        mock_scraper.side_effect = lambda html, url, failed: (
+            None if url == "u2" else {"title": url}
+        )
+        target: dict[str, dict] = {}
+        failed: dict[str, str] = {}
+
+        recipe_processor._scrape_urls_streaming(
+            ["u1", "u2", "u3"], target, "unused_mains_recipes.json", failed, False
+        )
+
+        assert target == {"u1": {"title": "u1"}, "u3": {"title": "u3"}}
+        assert "u2" not in target
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_streams_one_call_per_url(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        mock_get_html.return_value = "html"
+        mock_scraper.return_value = {"title": "x"}
+        urls = [f"u{i}" for i in range(7)]
+
+        recipe_processor._scrape_urls_streaming(
+            urls, {}, "unused_mains_recipes.json", {}, False
+        )
+
+        assert mock_get_html.call_count == 7
+        assert mock_scraper.call_count == 7
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_periodic_flush_plus_final(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        mock_get_html.return_value = "html"
+        mock_scraper.return_value = {"title": "x"}
+
+        recipe_processor._scrape_urls_streaming(
+            [f"u{i}" for i in range(5)],
+            {},
+            "unused_mains_recipes.json",
+            {},
+            False,
+            flush_interval=2,
+        )
+
+        # Flush after URLs 2 and 4, plus one final flush = 3 flushes.
+        # Each flush writes target file + FAILED_FILENAME = 2 saves.
+        target_saves = [
+            c for c in mock_save.call_args_list
+            if c.args[0] == "unused_mains_recipes.json"
+        ]
+        failed_saves = [
+            c for c in mock_save.call_args_list
+            if c.args[0] == config.FAILED_FILENAME
+        ]
+        assert len(target_saves) == 3
+        assert len(failed_saves) == 3
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_final_flush_always_happens(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        mock_get_html.return_value = "html"
+        mock_scraper.return_value = {"title": "x"}
+
+        recipe_processor._scrape_urls_streaming(
+            ["only"], {}, "unused_mains_recipes.json", {}, False, flush_interval=100
+        )
+
+        target_saves = [
+            c for c in mock_save.call_args_list
+            if c.args[0] == "unused_mains_recipes.json"
+        ]
+        assert len(target_saves) == 1
+
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_debug_mode_never_flushes(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        mock_get_html.return_value = "html"
+        mock_scraper.return_value = {"title": "x"}
+
+        recipe_processor._scrape_urls_streaming(
+            [f"u{i}" for i in range(5)],
+            {},
+            "unused_mains_recipes.json",
+            {},
+            True,
+            flush_interval=2,
+        )
+
+        mock_save.assert_not_called()

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -18,3 +18,26 @@ class TestScrapeFlushIntervalConfig:
 
     def test_flush_interval_exported(self) -> None:
         assert "SCRAPE_FLUSH_INTERVAL" in config.__all__
+
+
+class TestFlushScrapeProgress:
+    """Test the _flush_scrape_progress disk-persist helper."""
+
+    @patch("recipe_processor.save_json")
+    def test_flush_writes_target_and_failed(self, mock_save: Mock) -> None:
+        target = {"u1": {"title": "a"}}
+        failed = {"bad": "reason"}
+        recipe_processor._flush_scrape_progress(
+            "unused_mains_recipes.json", target, failed, debug_mode=False
+        )
+        # Writes exactly the active stream's file + the failed-recipes file.
+        assert mock_save.call_count == 2
+        mock_save.assert_any_call("unused_mains_recipes.json", target)
+        mock_save.assert_any_call(config.FAILED_FILENAME, failed)
+
+    @patch("recipe_processor.save_json")
+    def test_flush_is_noop_in_debug_mode(self, mock_save: Mock) -> None:
+        recipe_processor._flush_scrape_progress(
+            "unused_mains_recipes.json", {"u1": {}}, {}, debug_mode=True
+        )
+        mock_save.assert_not_called()

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -105,12 +105,12 @@ class TestScrapeUrlsStreaming:
         # Flush after URLs 2 and 4, plus one final flush = 3 flushes.
         # Each flush writes target file + FAILED_FILENAME = 2 saves.
         target_saves = [
-            c for c in mock_save.call_args_list
+            c
+            for c in mock_save.call_args_list
             if c.args[0] == "unused_mains_recipes.json"
         ]
         failed_saves = [
-            c for c in mock_save.call_args_list
-            if c.args[0] == config.FAILED_FILENAME
+            c for c in mock_save.call_args_list if c.args[0] == config.FAILED_FILENAME
         ]
         assert len(target_saves) == 3
         assert len(failed_saves) == 3
@@ -129,7 +129,8 @@ class TestScrapeUrlsStreaming:
         )
 
         target_saves = [
-            c for c in mock_save.call_args_list
+            c
+            for c in mock_save.call_args_list
             if c.args[0] == "unused_mains_recipes.json"
         ]
         assert len(target_saves) == 1

--- a/tests/test_recipe_processor_baseline.py
+++ b/tests/test_recipe_processor_baseline.py
@@ -155,6 +155,29 @@ class TestScrapeUrlsStreaming:
 
         mock_save.assert_not_called()
 
+    @patch("recipe_processor.save_json")
+    @patch("recipe_processor.scraper")
+    @patch("recipe_processor.get_html")
+    def test_empty_url_list_still_flushes_once(
+        self, mock_get_html: Mock, mock_scraper: Mock, mock_save: Mock
+    ) -> None:
+        recipe_processor._scrape_urls_streaming(
+            [], {}, "unused_mains_recipes.json", {}, False
+        )
+
+        mock_get_html.assert_not_called()
+        mock_scraper.assert_not_called()
+        target_saves = [
+            c
+            for c in mock_save.call_args_list
+            if c.args[0] == "unused_mains_recipes.json"
+        ]
+        failed_saves = [
+            c for c in mock_save.call_args_list if c.args[0] == config.FAILED_FILENAME
+        ]
+        assert len(target_saves) == 1
+        assert len(failed_saves) == 1
+
 
 class TestFetchFreshRecipesStreaming:
     """End-to-end: fetch_fresh_recipes streams mains then sides, no batch dicts."""


### PR DESCRIPTION
## Summary
- `recipe_processor.fetch_fresh_recipes` no longer loads every recipe page's HTML into memory before scraping (the `main_htmls`/`side_htmls` batch dicts held multiple GB at once and OOM-crashed the Raspberry Pi 4 on large first runs).
- New `_scrape_urls_streaming` helper fetches + scrapes **one page at a time** (`del html` each iteration), so peak memory is a single page instead of all of them.
- New `_flush_scrape_progress` helper persists the **active stream's** file + `failed_recipes.json` every `SCRAPE_FLUSH_INTERVAL` (=100) processed URLs and once at the end, so an interrupted/rebooted run is resumable via the existing dedup phase.
- Deleted the whole-DB `print(f"... {unused_main_recipes=}")` repr dumps that flooded the log.
- No behavior change to *which* recipes are scraped/selected: signature and the `(unused_main_recipes, unused_side_recipes)` 2-tuple return are unchanged, so `main.py` is untouched. Debug mode never writes the DB files (flush is a no-op).

Design: `docs/superpowers/specs/2026-05-30-streaming-scrape-design.md`.

## Test Plan
- [x] New `tests/test_recipe_processor_baseline.py` (11 tests): routing/None-skip, one-call-per-URL streaming, periodic-flush count, final-flush-always, empty-list still flushes once, debug-never-flushes, and end-to-end 2-tuple + repr-gone.
- [x] Full suite green: `84 passed`.
- [x] `ruff check .` + `black --check .` clean.
- [x] `python -c "import recipe_processor; import main"` imports clean.

## Rebase note
This is a pre-existing bug on `main` (identical code on #52/#53). Intended to merge **first**; then #52 and #53 rebase onto it. #52 also modifies `fetch_fresh_recipes` (RunOutcome collection + 3-tuple), so its rebase will conflict in `recipe_processor.py` — resolution keeps this streamed phase **and** #52's RunOutcome/3-tuple return.

## Summary by Sourcery

Stream recipe scraping to reduce memory usage and make progress durable on disk during long runs.

New Features:
- Introduce a streaming HTML scraping helper that fetches and processes one recipe page at a time for mains and sides.
- Persist scrape progress and failed-recipes metadata periodically and at the end of a run, controlled by a configurable flush interval.

Enhancements:
- Replace batch HTML loading in recipe fetching with streaming to bound peak memory usage and improve resilience on constrained devices.
- Simplify logging by replacing large unused-recipe repr dumps with concise count summaries.

Tests:
- Add characterization tests covering the streaming scrape behavior, flush interval configuration, debug-mode no-op flushing, and end-to-end fetch_fresh_recipes output.