### PR TITLE
feat: publish weekly menu to GitHub Pages (gh-pages branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ __pycache__/
 *.egg-info/
 *.log
 *.log.*
+# Generated weekly page (published to the gh-pages branch by cook.sh, not main)
+index.html
+.gh-pages-worktree/
 #unused_mains_recipes.json
 #unused_sides_recipes.json
 #used_recipes.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ scrape (recipe_processor → web_scraper)
   → ensure veggies / add sides (recipe_selector.ensure_veggies)
   → render (html_generator.generate_html_email)
   → send (email_sender.send_email)
-  → publish to website (website_publisher.publish_meals_page)
+  → write publish page (website_publisher.write_publish_page → index.html)
   → update tracking JSON (file_utils.save_json)
 ```
 
@@ -65,13 +65,13 @@ Recipes are categorized seafood vs. landfood by substring-matching `SEAFOOD_PROT
 
 `WEBSITES` maps a site name → `{regex, "main course" url, "side dish" url}`. Each site's index pages are fetched and `regex` extracts individual recipe URLs. URLs are filtered through `URL_EXCLUSION_PATTERNS` (tuple of keyword-AND groups) and individual recipe pages are parsed by the `hhursev` `recipe_scrapers` lib. Site HTML structures drift — a failing site usually means its `regex` needs updating. Failures are caught and recorded in `failed_recipes`, never fatal (this runs unattended).
 
-### Email + website publish
+### Email + page publish
 
-`head.html` (repo root) supplies the email's `<head>`/CSS; `html_generator` appends `<body>` cards. `website_publisher` extracts that `<body>`, re-wraps it in the external website's template (`WEBSITE_REPO_PATH` env, with `templates/navbar.html`), writes `meals.html`, and git commit/pushes to that separate repo. Skipped if `WEBSITE_REPO_PATH` is unset or in debug mode.
+`head.html` (repo root) supplies the email's `<head>`/CSS; `html_generator` produces a complete self-contained HTML document. `website_publisher.write_publish_page` writes that same HTML verbatim to `PUBLISH_PAGE_FILENAME` (`index.html`); `cook.sh` then commits + pushes it to the `gh-pages` branch via a throwaway git worktree (so the main working tree / recipe JSONs are untouched). The write step is skipped in debug mode; the push is a self-contained, deletable block in `cook.sh`. `index.html` is gitignored on `main`.
 
 ## Configuration
 
-`.env` (required): `SENDER`, `PASSWD` (Gmail app password), `BCC` (comma-separated recipients). Optional: `WEBSITE_REPO_PATH`.
+`.env` (required): `SENDER`, `PASSWD` (Gmail app password), `BCC` (comma-separated recipients).
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,31 @@ crontab -e
 
 Adjust the path to wherever you cloned the repo.
 
+### Publishing to GitHub Pages (optional)
+
+Each run writes a self-contained `index.html` (the same content as the email).
+`cook.sh` commits + pushes it to a **`gh-pages` branch** of this repo, so your
+weekly menu is served at `https://<user>.github.io/<repo>/` — without ever adding
+generated pages to your `main` history.
+
+One-time setup:
+
+```bash
+# Create an empty gh-pages branch with a first index.html
+git switch --orphan gh-pages
+git commit --allow-empty -m "init gh-pages"
+git push -u origin gh-pages
+git switch main
+```
+
+Then enable Pages in the repo settings (**Settings → Pages → Build from branch →
+`gh-pages` / root**). After that, every `cook.sh` run publishes automatically.
+
+`index.html` is gitignored on `main` and pushed via a throwaway git worktree, so
+the publish step never touches your working tree or the recipe JSON files. **To
+disable publishing, delete the marked block in `cook.sh`** — the rest of the run
+(scrape, email) is unaffected.
+
 ## 📋 Features
 
 ### Core Functionality
@@ -142,10 +167,10 @@ backfill_seasonality.py  One-off tagger for the existing backlog
 site_health.py           Scraper regex-failure / reachability monitoring
 html_generator.py        Email HTML generation
 email_sender.py          SMTP email delivery
-website_publisher.py     Publish the meals page to the external website repo
+website_publisher.py     Write the standalone index.html page for publishing
 debug_utils.py           Debug-mode utilities
 pyproject.toml           Project + tooling configuration
-tests/                   Test suite (159 tests)
+tests/                   Test suite
 ```
 
 ### Data Flow
@@ -160,7 +185,8 @@ tests/                   Test suite (159 tests)
    ensure veggies/sides, bias toward in-season picks.
 6. **Render** (`html_generator.py`) — build the email HTML.
 7. **Send** (`email_sender.py`) — SMTP delivery.
-8. **Publish** (`website_publisher.py`) — push the meals page to the website repo.
+8. **Write page** (`website_publisher.py`) — write the standalone `index.html`;
+   `cook.sh` then commits + pushes it to the `gh-pages` branch.
 9. **Persist** (`file_utils.py`) — move sent recipes to used, save tracking JSON.
 
 ## 🧪 Testing
@@ -246,7 +272,6 @@ Set in `.env` (loaded via `python-dotenv`):
 | `SENDER` | ✅ | Gmail address for sending |
 | `PASSWD` | ✅ | Gmail app password |
 | `BCC` | ✅ | Comma-separated recipients |
-| `WEBSITE_REPO_PATH` | ❌ | Path to a separate website repo; when set, the meals page is published there (otherwise this step is skipped) |
 
 ### Configurable Constants
 

--- a/config.py
+++ b/config.py
@@ -32,6 +32,7 @@ __all__ = [
     "NORMAL_TIMEOUT",
     "OLLAMA_HOST",
     "OLLAMA_TIMEOUT",
+    "PUBLISH_PAGE_FILENAME",
     "REQUIRED_RECIPE_KEYS",
     "SCRAPE_FLUSH_INTERVAL",
     "SEAFOOD_COUNT",
@@ -54,7 +55,6 @@ __all__ = [
     "USED_FILENAME",
     "VEGGIES",
     "VERSION",
-    "WEBSITE_REPO_PATH",
     "WINTER_CENTER",
 ]
 
@@ -71,6 +71,10 @@ FAILED_FILENAME: Final[str] = "failed_recipes.json"
 USED_FILENAME: Final[str] = "used_recipes.json"
 SITE_HEALTH_FILENAME: Final[str] = "site_health.json"
 HEALTH_SUBJECT: Final[str] = "Recipe Emailer — Site Health"
+
+# Standalone HTML page written each run for GitHub Pages publishing. cook.sh
+# commits + pushes this file to the gh-pages branch (see README).
+PUBLISH_PAGE_FILENAME: Final[str] = "index.html"
 
 # FILE AGE THRESHOLD (in hours)
 FILE_AGE_THRESHOLD: Final[int] = 12
@@ -94,7 +98,6 @@ SMTP_PORT: Final[int] = 465
 EMAIL_SENDER: Final[str | None] = os.getenv("SENDER")
 EMAIL_PASSWORD: Final[str | None] = os.getenv("PASSWD")
 EMAIL_BCC: Final[str | None] = os.getenv("BCC")
-WEBSITE_REPO_PATH: Final[str | None] = os.getenv("WEBSITE_REPO_PATH")
 
 # REQUIRED RECIPE KEYS
 REQUIRED_RECIPE_KEYS: Final[tuple[str, ...]] = (

--- a/cook.sh
+++ b/cook.sh
@@ -18,6 +18,30 @@ fi
 
 python main.py >> cronjob.log
 
+# --- Publish to GitHub Pages (delete this block to disable) ----------------- #
+# main.py writes index.html each run. Publish it to the gh-pages branch via a
+# detached worktree so the main working tree (and its uncommitted recipe JSONs)
+# is never touched. Requires a one-time setup -- see "GitHub Pages" in README.
+if [ -f index.html ]; then
+    publish_gh_pages() {
+        local wt=".gh-pages-worktree"
+        # Check out gh-pages into a throwaway worktree (track remote if present).
+        git worktree add --quiet -B gh-pages "$wt" origin/gh-pages 2>/dev/null \
+            || git worktree add --quiet "$wt" gh-pages || return 1
+        cp index.html "$wt/index.html"
+        git -C "$wt" add index.html
+        if git -C "$wt" diff --cached --quiet; then
+            echo "gh-pages: no change to index.html"
+        else
+            git -C "$wt" commit --quiet -m "Update weekly meals $(date +%F)"
+            git -C "$wt" push --quiet origin gh-pages
+        fi
+        git worktree remove --force "$wt"
+    }
+    publish_gh_pages >> cronjob.log 2>&1 || echo "gh-pages publish failed" >> cronjob.log
+fi
+# --------------------------------------------------------------------------- #
+
 # Keep cronjob.log bounded: retain only the most recent ~2000 lines (dozens of
 # weekly runs, well under a megabyte) so the log can't grow without limit.
 tail -n 2000 cronjob.log > cronjob.log.tmp && mv cronjob.log.tmp cronjob.log

--- a/cook.sh
+++ b/cook.sh
@@ -25,9 +25,14 @@ python main.py >> cronjob.log
 if [ -f index.html ]; then
     publish_gh_pages() {
         local wt=".gh-pages-worktree"
-        # Check out gh-pages into a throwaway worktree (track remote if present).
-        git worktree add --quiet -B gh-pages "$wt" origin/gh-pages 2>/dev/null \
-            || git worktree add --quiet "$wt" gh-pages || return 1
+        # Clean up any leftover worktree from a previously interrupted run.
+        git worktree remove --force "$wt" 2>/dev/null
+        rm -rf "$wt"
+        # Make sure we have the remote gh-pages branch (a fresh clone / the Pi
+        # may never have fetched it). Without this, origin/gh-pages won't exist.
+        git fetch --quiet origin gh-pages || return 1
+        # Check out gh-pages into a throwaway worktree at the remote tip.
+        git worktree add --quiet -B gh-pages "$wt" origin/gh-pages || return 1
         cp index.html "$wt/index.html"
         git -C "$wt" add index.html
         if git -C "$wt" diff --cached --quiet; then
@@ -35,10 +40,13 @@ if [ -f index.html ]; then
         else
             git -C "$wt" commit --quiet -m "Update weekly meals $(date +%F)"
             git -C "$wt" push --quiet origin gh-pages
+            echo "gh-pages: pushed update"
         fi
         git worktree remove --force "$wt"
     }
     publish_gh_pages >> cronjob.log 2>&1 || echo "gh-pages publish failed" >> cronjob.log
+else
+    echo "gh-pages: no index.html written (debug run or earlier failure?)" >> cronjob.log
 fi
 # --------------------------------------------------------------------------- #
 

--- a/main.py
+++ b/main.py
@@ -21,13 +21,13 @@ from config import (
     FAILED_FILENAME,
     FILE_AGE_THRESHOLD,
     HEALTH_SUBJECT,
+    PUBLISH_PAGE_FILENAME,
     SITE_HEALTH_FILENAME,
     SUBJECT,
     UNUSED_MAINS_FILENAME,
     UNUSED_SIDES_FILENAME,
     USED_FILENAME,
     VEGGIES,
-    WEBSITE_REPO_PATH,
 )
 from debug_utils import is_debug_mode, select_website_interactively
 from email_sender import send_email
@@ -44,7 +44,7 @@ from site_health import (
     record_run,
     render_health_email,
 )
-from website_publisher import publish_meals_page
+from website_publisher import write_publish_page
 from websites import WEBSITES
 
 __all__ = ["main"]
@@ -111,9 +111,10 @@ def main() -> None:
         # Generate and send email
         html_content = _generate_and_send_email(context, meals, start_time, debug_mode)
 
-        # Publish meals page to website (skip in debug mode)
+        # Write the standalone page for publishing (skip in debug mode).
+        # cook.sh commits + pushes it to the gh-pages branch.
         if not debug_mode:
-            _publish_meals_to_website(html_content)
+            _write_publish_page(html_content)
 
         # Update tracking data (skip in debug mode)
         if not debug_mode:
@@ -355,17 +356,18 @@ def _update_tracking_data(context: dict[str, Any], meals: list[dict[str, Any]]) 
     )
 
 
-def _publish_meals_to_website(html_content: str) -> None:
-    """Publish meals page to website repo with error notification on failure."""
-    if not WEBSITE_REPO_PATH:
-        logger.warning("WEBSITE_REPO_PATH not set, skipping website publish")
-        return
+def _write_publish_page(html_content: str) -> None:
+    """Write the standalone meals page for GitHub Pages; never raises.
 
+    cook.sh commits + pushes this file to the gh-pages branch. A write failure
+    logs + emails the maintainer but must not break the run (the email already
+    went out by this point).
+    """
     try:
-        publish_meals_page(html_content, WEBSITE_REPO_PATH)
+        write_publish_page(html_content, PUBLISH_PAGE_FILENAME)
     except Exception as e:
-        logger.exception(f"Failed to publish meals page: {e}")
-        _send_error_notification(e, subject="Recipe Emailer - Website Publish Error")
+        logger.exception(f"Failed to write publish page: {e}")
+        _send_error_notification(e, subject="Recipe Emailer - Publish Page Error")
 
 
 def _send_error_notification(

--- a/tests/test_main_email_baseline.py
+++ b/tests/test_main_email_baseline.py
@@ -69,3 +69,24 @@ class TestSendErrorNotification:
         # Must not propagate -- error notification is best-effort.
         main._send_error_notification(ValueError("boom"))
         mock_logger.error.assert_called_once()
+
+
+class TestWritePublishPage:
+    """Tests for _write_publish_page."""
+
+    @patch("main.write_publish_page")
+    def test_writes_to_configured_filename(self, mock_write) -> None:
+        """The page is written to PUBLISH_PAGE_FILENAME with the email HTML."""
+        main._write_publish_page("<html>menu</html>")
+        mock_write.assert_called_once_with(
+            "<html>menu</html>", main.PUBLISH_PAGE_FILENAME
+        )
+
+    @patch("main._send_error_notification")
+    @patch("main.write_publish_page", side_effect=OSError("disk full"))
+    def test_write_failure_notifies_and_does_not_raise(
+        self, _mock_write, mock_notify
+    ) -> None:
+        """A write failure emails the maintainer and is swallowed (run continues)."""
+        main._write_publish_page("<html>x</html>")
+        mock_notify.assert_called_once()

--- a/tests/test_website_publisher.py
+++ b/tests/test_website_publisher.py
@@ -1,0 +1,35 @@
+"""Tests for website_publisher.write_publish_page."""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+import website_publisher
+
+
+class TestWritePublishPage:
+    """Tests for write_publish_page."""
+
+    def test_writes_html_verbatim(self, tmp_path: Path) -> None:
+        """The email HTML is written to the output path unchanged."""
+        out = tmp_path / "index.html"
+        html = "<!DOCTYPE html><html><body><div class='card'>Meal</div></body></html>"
+
+        website_publisher.write_publish_page(html, str(out))
+
+        assert out.read_text(encoding="utf-8") == html
+
+    def test_overwrites_existing_file(self, tmp_path: Path) -> None:
+        """A subsequent run replaces last week's page."""
+        out = tmp_path / "index.html"
+        out.write_text("old page", encoding="utf-8")
+
+        website_publisher.write_publish_page("<html>new</html>", str(out))
+
+        assert out.read_text(encoding="utf-8") == "<html>new</html>"
+
+    def test_preserves_unicode(self, tmp_path: Path) -> None:
+        """Non-ASCII content (e.g. en-dashes) is written as UTF-8, not mangled."""
+        out = tmp_path / "index.html"
+        website_publisher.write_publish_page("<p>5–6 minutes</p>", str(out))
+        assert "5–6" in out.read_text(encoding="utf-8")

--- a/website_publisher.py
+++ b/website_publisher.py
@@ -1,158 +1,20 @@
-"""Website publishing functionality for the meals page."""
+"""Write the weekly meals page for GitHub Pages publishing.
+
+The email HTML produced by ``html_generator`` is already a complete, self-contained
+document (``<!DOCTYPE>`` + inline CSS), so publishing is just writing it to a file
+the web server serves. cook.sh commits + pushes that file to the gh-pages branch;
+this module only produces the artifact.
+"""
 
 from __future__ import annotations
 
 import logging
-import os
-import subprocess  # nosec B404
-from datetime import datetime
 
 logger = logging.getLogger(__name__)
 
 
-def publish_meals_page(email_html: str, website_repo_path: str) -> None:
-    """Write meals.html to the website repo and push changes.
-
-    Takes the email HTML content, wraps it in the website's template,
-    writes it to meals.html, and commits/pushes to the website repo.
-    """
-    logger.info("Publishing meals page to website repo")
-
-    meals_html = generate_meals_page_html(email_html, website_repo_path)
-
-    meals_path = os.path.join(website_repo_path, "meals.html")
-    with open(meals_path, "w", encoding="utf-8") as f:
-        f.write(meals_html)
-    logger.info(f"Wrote meals page to {meals_path}")
-
-    _git_commit_and_push(website_repo_path)
-
-
-def generate_meals_page_html(email_html: str, website_repo_path: str) -> str:
-    """Generate a website-compatible meals.html page from email HTML content."""
-    # Extract recipe card content from email HTML body
-    body_start = email_html.index("<body>") + len("<body>")
-    body_end = email_html.index("</body>")
-    recipe_content = email_html[body_start:body_end].strip()
-
-    # Read navbar template from website repo
-    navbar_path = os.path.join(website_repo_path, "templates", "navbar.html")
-    with open(navbar_path, encoding="utf-8") as f:
-        navbar = f.read()
-
-    year = datetime.now().year
-
-    return f"""<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>MEALS</title>
-    <link rel="stylesheet" href="styles/default.css">
-    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Kaushan+Script" rel="stylesheet" type="text/css">
-    <style>
-      .meals-content {{
-        font-family: "Roboto", sans-serif;
-        background-color: #f8f4f0;
-        color: #494949;
-        padding: 20px;
-        border-radius: 10px;
-      }}
-      .meals-content h1 {{
-        font-family: "Kaushan Script", cursive;
-        color: #e07a5f;
-        margin: 0;
-        font-size: 1.8rem;
-        text-align: left;
-      }}
-      .meals-content h2 {{
-        font-family: "Kaushan Script", cursive;
-        color: #6d6875;
-        margin-bottom: 10px;
-        background-color: transparent;
-        font-size: 1.4rem;
-      }}
-      .meals-content i {{
-        color: #888;
-        display: block;
-        margin-top: 0;
-      }}
-      .meals-content p {{
-        color: #555;
-        margin-top: 0;
-      }}
-      .meals-content ul {{
-        list-style-type: none;
-        padding: 0;
-      }}
-      .meals-content li {{
-        color: #666;
-        margin-bottom: 5px;
-      }}
-      .meals-content .card {{
-        background-color: #fbe2d4;
-        border-radius: 20px;
-        padding: 20px;
-        margin-bottom: 30px;
-      }}
-      .meals-content .polaroid {{
-        margin: 10px;
-        position: relative;
-        width: 220px;
-      }}
-      .meals-content .polaroid img {{
-        max-width: 250px;
-        max-height: 250px;
-        border-radius: 2px;
-        border: 10px solid #fff;
-        border-bottom: 35px solid #fff;
-      }}
-    </style>
-  </head>
-  <body>
-    {navbar}
-    <div class="container">
-      <header><h1>Weekly Meals</h1></header>
-      <div class="meals-content">
-        {recipe_content}
-      </div>
-    </div>
-    <footer>
-      <p>&copy; {year} Luke Wass | Whatever you do, work at it with all your heart, as working for the Lord, not for men.</p>
-    </footer>
-  </body>
-  <script src="static/js/nav.js"></script>
-</html>
-"""
-
-
-def _git_commit_and_push(repo_path: str) -> None:
-    """Add, commit, and push meals.html in the website repo."""
-
-    def run_git(*args: str) -> subprocess.CompletedProcess[str]:
-        return subprocess.run(
-            ["git", *args],
-            cwd=repo_path,
-            capture_output=True,
-            text=True,
-            check=True,
-        )  # nosec B603 B607
-
-    run_git("add", "meals.html")
-
-    # Check if there are staged changes
-    result = subprocess.run(
-        ["git", "diff", "--cached", "--quiet"],
-        cwd=repo_path,
-        capture_output=True,
-    )  # nosec B603 B607
-
-    if result.returncode == 0:
-        logger.info("No changes to meals.html, skipping commit")
-        return
-
-    date_str = datetime.now().strftime("%Y-%m-%d")
-    run_git("commit", "-m", f"Update weekly meals {date_str}")
-    run_git("push")
-    logger.info("Successfully pushed meals page update")
+def write_publish_page(email_html: str, output_path: str) -> None:
+    """Write the email HTML to output_path as the standalone meals page."""
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(email_html)
+    logger.info(f"Wrote publish page to {output_path}")


### PR DESCRIPTION
## Summary

Publishes the weekly menu to **GitHub Pages** from this same repo, served at
`https://<user>.github.io/<repo>/`, replacing the old `WEBSITE_REPO_PATH`
external-repo push.

Responsibility is split cleanly:
- **`main.py` writes the artifact.** Each run writes a self-contained `index.html`
  (the email HTML is already a complete document) via `website_publisher.write_publish_page`. Skipped in debug mode; failure is logged + emailed, never fatal.
- **`cook.sh` deploys it.** A clearly-marked, **deletable** block commits + pushes
  `index.html` to a `gh-pages` branch through a throwaway git worktree — so the
  main working tree and the recipe JSON files are never touched, and generated
  pages never land in `main`'s history.

## Why this shape

- Generating output is the app's job; deploying-by-pushing is an ops action, and
  `cook.sh` is already the ops layer (venv, log rotation). Forkers who don't want
  publishing just delete one fenced block.
- Publishing to `gh-pages` (not `main`) keeps weekly content commits off the code
  history — no pull/push divergence between dev machine and the Pi.

## Changes

- New `website_publisher.write_publish_page()` (thin file writer); removed the old
  external-repo/navbar/`meals.html` git-push path.
- `config`: drop `WEBSITE_REPO_PATH`, add `PUBLISH_PAGE_FILENAME = "index.html"`.
- `main._write_publish_page` writes the page (was `_publish_meals_to_website`).
- `cook.sh`: removable gh-pages publish block (worktree-based, no-op when unchanged).
- `.gitignore`: `index.html` + `.gh-pages-worktree/`.
- Docs: README "Publishing to GitHub Pages" setup section; CLAUDE.md updated.

## Setup (one-time, in README)

Create an orphan `gh-pages` branch, push it, then enable Settings → Pages →
`gh-pages` / root. After that every `cook.sh` run publishes automatically.

## Test Plan

- [x] 255 tests pass (+5: `test_website_publisher.py`, `_write_publish_page` cases)
- [x] ruff + black + interrogate (≥95%) + bandit clean; changed modules mypy-strict clean
- [x] `bash -n cook.sh` clean; publish block no-ops when index.html is unchanged

## Summary by Sourcery

Publish the generated weekly meals HTML as a standalone page and wire the app and shell script to deploy it via a gh-pages branch instead of an external website repo.

New Features:
- Add support for writing a self-contained index.html each run for GitHub Pages publishing via a configurable publish filename.

Enhancements:
- Simplify website publishing by replacing the external-repo meals.html generation and git push logic with a thin file-writer helper and a non-fatal publish step in main.
- Update configuration to drop WEBSITE_REPO_PATH and introduce PUBLISH_PAGE_FILENAME, and adjust internal documentation and developer notes to describe the new GitHub Pages–based flow.
- Extend cook.sh with a removable gh-pages publish block that uses a temporary git worktree so generated pages never touch the main working tree or history.

Documentation:
- Document optional GitHub Pages setup and publishing behavior in the README, and update architecture notes to match the new publish flow.

Tests:
- Add tests for the website_publisher.write_publish_page helper and for main._write_publish_page error handling and configuration use.